### PR TITLE
adding ggPhenotypebyDegree

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Adding twin plotting features
 * Added ability to fill colors as a function of the degree of relatedness to a focal person
 * Add getDefaultPlotConfig functionality to ggPhenotypebyDegree
+* Fully documented getDefaultPlotConfig so that each config option is clear and understandable.
 
 # ggpedigree 0.4.1
 ## Status: Submitted to CRAN

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Added workaround for plotly non-support for geom_curve with computeCurvedMidpoint
 * Adding twin plotting features
 * Added ability to fill colors as a function of the degree of relatedness to a focal person
+* Add getDefaultPlotConfig functionality to ggPhenotypebyDegree
 
 # ggpedigree 0.4.1
 ## Status: Submitted to CRAN

--- a/R/defaultPlotConfig.R
+++ b/R/defaultPlotConfig.R
@@ -82,6 +82,7 @@
 #' @param segment_self_angle Angle of self-loop segment.
 #' @param segment_self_curvature Curvature of self-loop segment.
 #' @param sex_color_include Whether to color nodes by sex.
+#' @param sex_color_palette A character vector of colors for sex.
 #' @param sex_legend_title Title of the sex legend.
 #' @param sex_shape_labels Labels used in sex legend.
 #' @param sex_shape_female Shape for female nodes.
@@ -95,6 +96,7 @@
 #' @param status_alpha_affected Alpha for affected individuals.
 #' @param status_alpha_unaffected Alpha for unaffected individuals.
 #' @param status_affected_shape Shape for affected individuals.
+#' @param status_color_palette A character vector of colors for affected status.
 #' @param status_legend_title Title of the status legend.
 #' @param status_legend_show Whether to show the status legend.
 #' @param focal_fill_include Whether to fill focal individuals.

--- a/R/defaultPlotConfig.R
+++ b/R/defaultPlotConfig.R
@@ -1,25 +1,277 @@
 # defaultPlotConfig.R
 #' @title Shared Default Plotting Configuration
 #' @description Centralized configuration list used by all gg-based plotting functions.
+#' Returns a named list of default settings used by all gg-based plotting functions.
+#' This configuration can be overridden by supplying a list of key-value pairs to
+#' plotting functions such as `ggPedigree()`, `ggRelatednessMatrix()`, and `ggPhenotypeByDegree()`.
+#' Each key corresponds to a configurable plot, layout, or aesthetic behavior.
 #' @param color_palette_default A character vector of default colors for the plot.
 #' @param segment_default_color A character string for the default color of segments in the plot.
 #' @param function_name The name of the function calling this configuration.
 #' @param personID The column name for person identifiers in the data.
 #' @param status_column The column name for affected status in the data.
-#' @param color_scale_midpoint A numeric value for the midpoint of the color scale.
+#' @param color_scale_midpoint Midpoint value for continuous color scales.
+#' @param alpha_default Default alpha transparency level.
+#' @param apply_default_scales Whether to apply default color scales.
+#' @param apply_default_theme Whether to apply default ggplot2 theme.
+#' @param color_palette_low Color for the low end of a gradient.
+#' @param color_palette_mid Color for the midpoint of a gradient.
+#' @param color_palette_high Color for the high end of a gradient.
+#' @param color_scale Name of the color scale used (e.g., "ggthemes::calc").
+#' @param alpha Default alpha transparency for plot elements.
+#' @param plot_title Main title of the plot.
+#' @param plot_subtitle Subtitle of the plot.
+#' @param value_rounding_digits Number of digits to round displayed values.
+#' @param code_male Integer code for males in data.
+#' @param filter_n_pairs Threshold to filter maximum number of pairs.
+#' @param filter_degree_min Minimum degree value used in filtering.
+#' @param filter_degree_max Maximum degree value used in filtering.
+#' @param drop_classic_kin Whether to exclude classic kin categories.
+#' @param drop_non_classic_sibs Whether to exclude non-classic sibs.
+#' @param use_only_classic_kin Whether to restrict analysis to classic kinship.
+#' @param use_relative_degree Whether to use relative degrees instead of absolute.
+#' @param group_by_kin Whether to group output by kinship group.
+#' @param match_threshold_percent Kinbin matching threshold as a percentage.
+#' @param max_degree_levels Maximum number of degree levels to show.
+#' @param grouping_column Name of column used for grouping.
+#' @param annotate_include Whether to include annotations.
+#' @param annotate_x_shift Horizontal shift applied to annotation text.
+#' @param annotate_y_shift Vertical shift applied to annotation text.
+#' @param label_include Whether to display labels on plot points.
+#' @param label_column Column to use for text labels.
+#' @param label_method Method used for labeling (e.g., ggrepel, geom_text).
+#' @param label_max_overlaps Maximum number of overlapping labels.
+#' @param label_nudge_x Horizontal nudge for label text.
+#' @param label_nudge_y Vertical nudge for label text.
+#' @param label_segment_color Segment color for label connectors.
+#' @param label_text_angle Text angle for labels.
+#' @param label_text_size Font size for labels.
+#' @param label_text_color Color of the label text.
+#' @param point_size Size of points drawn in plot.
+#' @param outline_include Whether to include outlines around points.
+#' @param outline_multiplier Multiplier to compute outline size from point size.
+#' @param outline_color Color used for point outlines.
+#' @param tooltip_include Whether tooltips are shown in interactive plots.
+#' @param tooltip_columns Columns to include in tooltips.
+#' @param axis_x_label Label for the X-axis.
+#' @param axis_y_label Label for the Y-axis.
+#' @param axis_text_angle_x Angle of X-axis text.
+#' @param axis_text_angle_y Angle of Y-axis text.
+#' @param axis_text_size Font size of axis text.
+#' @param axis_text_color Color of axis text.
+#' @param generation_height Vertical spacing of generations.
+#' @param generation_width Horizontal spacing of generations.
+#' @param ped_packed Whether the pedigree should use packed layout.
+#' @param ped_align Whether to align pedigree generations.
+#' @param ped_width Plot width of the pedigree block.
+#' @param segment_linewidth Line width for segments.
+#' @param segment_linetype Line type for segments.
+#' @param segment_lineend Line end type for segments.
+#' @param segment_linejoin Line join type for segments.
+#' @param segment_offspring_color Color for offspring segments.
+#' @param segment_parent_color Color for parent segments.
+#' @param segment_self_color Color for self-loop segments.
+#' @param segment_sibling_color Color for sibling segments.
+#' @param segment_spouse_color Color for spouse segments.
+#' @param segment_mz_color Color for monozygotic twin segments.
+#' @param segment_mz_linetype Line type for MZ segments.
+#' @param segment_mz_alpha Alpha for MZ segments.
+#' @param segment_mz_t Tuning parameter for MZ segment layout.
+#' @param segment_self_linetype Line type for self-loop segments.
+#' @param segment_self_alpha Alpha value for self-loop segments.
+#' @param segment_self_angle Angle of self-loop segment.
+#' @param segment_self_curvature Curvature of self-loop segment.
+#' @param sex_color_include Whether to color nodes by sex.
+#' @param sex_legend_title Title of the sex legend.
+#' @param sex_shape_labels Labels used in sex legend.
+#' @param sex_shape_female Shape for female nodes.
+#' @param sex_shape_male Shape for male nodes.
+#' @param sex_shape_unknown Shape for unknown sex nodes.
+#' @param status_include Whether to display affected status.
+#' @param status_code_affected Value that encodes affected status.
+#' @param status_code_unaffected Value that encodes unaffected status.
+#' @param status_label_affected Label for affected status.
+#' @param status_label_unaffected Label for unaffected status.
+#' @param status_alpha_affected Alpha for affected individuals.
+#' @param status_alpha_unaffected Alpha for unaffected individuals.
+#' @param status_affected_shape Shape for affected individuals.
+#' @param status_legend_title Title of the status legend.
+#' @param status_legend_show Whether to show the status legend.
+#' @param focal_fill_include Whether to fill focal individuals.
+#' @param focal_fill_legend_show Whether to show legend for focal fill.
+#' @param focal_fill_personID ID of focal individual.
+#' @param focal_fill_legend_title Title of focal fill legend.
+#' @param focal_fill_high_color High-end color for focal gradient.
+#' @param focal_fill_mid_color Midpoint color for focal gradient.
+#' @param focal_fill_low_color Low-end color for focal gradient.
+#' @param focal_fill_scale_midpoint Midpoint for focal fill scale.
+#' @param focal_fill_method Method used for focal fill gradient.
+#' @param focal_fill_component Component type for focal fill.
+#' @param focal_fill_n_breaks Number of breaks in focal fill scale.
+#' @param focal_fill_na_value Color for NA values in focal fill.
+#' @param focal_fill_force_zero Whether to force zero to NA in focal fill.
+#' @param ci_include Whether to show confidence intervals.
+#' @param ci_ribbon_alpha Alpha level for CI ribbons.
+#' @param matrix_sparse Whether matrix input is sparse.
+#' @param matrix_isChild_method Method used for isChild matrix derivation.
+#' @param return_static Whether to return a static plot.
+#' @param return_widget Whether to return a widget object.
+#' @param return_interactive Whether to return an interactive plot.
+#' @param override_many2many Whether to override many-to-many link logic.
 #' @param ... Additional arguments for future extensibility.
 #' @return A named list of default plotting and layout parameters.
 #' @export
 
 
-getDefaultPlotConfig <- function(color_palette_default =
-                                   c("#440154FF", "#FDE725FF", "#21908CFF"),
-                                 segment_default_color = "black",
-                                 function_name = "getDefaultPlotConfig",
-                                 personID = "personID",
-                                 color_scale_midpoint = 0.50,
-                                 alpha_default = 1,
-                                 status_column = NULL,
+getDefaultPlotConfig <- function( function_name = "getDefaultPlotConfig",
+                                   personID = "personID",
+                                   status_column = NULL,
+                                   alpha_default = 1,
+                                  # ---- General Appearance ----
+                                  apply_default_scales = TRUE,
+                                  apply_default_theme = TRUE,
+                                  segment_default_color = "black",
+                                  color_palette_default = c("#440154FF", "#FDE725FF", "#21908CFF"),
+                                  color_palette_low = "#000004FF",
+                                  color_palette_mid = "#56106EFF",
+                                  color_palette_high = "#FCFDBFFF",
+                                  color_scale_midpoint = 0.50,
+                                  color_scale = "ggthemes::calc", # only used in gg
+                                  alpha = alpha_default,
+                                  plot_title = NULL,
+                                  plot_subtitle = NULL,
+                                  value_rounding_digits = 2,
+                                  # --- SEX ------------------------------------------------------------
+                                  code_male = 1,
+
+                                  # ---- Filtering and Computation ----
+                                  filter_n_pairs = 500,
+                                  filter_degree_min = 0,
+                                  filter_degree_max = 7,
+                                  drop_classic_kin = FALSE,
+                                  drop_non_classic_sibs = TRUE,
+                                  use_only_classic_kin = TRUE,
+                                  use_relative_degree = TRUE,
+                                  group_by_kin = TRUE,
+
+                                  # ----Kinbin Settings ----
+                                  match_threshold_percent = 10,
+                                  max_degree_levels = 12,
+                                  grouping_column = "mtdna_factor",
+
+
+                                  # ---- Annotation Settings ----
+                                  annotate_include = TRUE,
+                                  annotate_x_shift = -0.1,
+                                  annotate_y_shift = 0.005,
+
+                                  # ---- Label Aesthetics ----
+                                  label_include = TRUE,
+                                  label_column = "personID",
+                                  label_method = "ggrepel",
+                                  label_max_overlaps = 15,
+                                  label_nudge_x = 0,
+                                  label_nudge_y = -0.10,
+                                  label_segment_color = NA,
+                                  label_text_angle = 0,
+                                  label_text_size = 2,
+                                  label_text_color = "black",
+
+                                  # --- POINT / OUTLINE AESTHETICS ---------------------------------------
+                                  point_size = 4,
+                                  outline_include = FALSE,
+                                  outline_multiplier = 1.25,
+                                  outline_color = "black",
+
+
+                                  # ---- Tooltip Aesthetics ----
+                                  tooltip_include = TRUE,
+                                  tooltip_columns = c("ID1", "ID2", "value"),
+
+                                  # ---- Axis and Layout Settings ----
+                                  axis_x_label = NULL,
+                                  axis_y_label = NULL,
+                                  axis_text_angle_x = 90,
+                                  axis_text_angle_y = 0,
+                                  axis_text_size = 8,
+                                  axis_text_color = "black",
+
+                                  # ---- Generation Scale Settings ----
+                                  generation_height = 1,
+                                  generation_width = 1,
+                                  ped_packed = TRUE,
+                                  ped_align = TRUE,
+                                  ped_width = 15,
+
+                                  # ---- Segment Drawing Options ----
+                                  segment_linewidth = 0.5,
+                                  segment_linetype = 1,
+                                  segment_lineend = "round",
+                                  segment_linejoin = "round",
+                                  segment_offspring_color = segment_default_color,
+                                  segment_parent_color = segment_default_color,
+                                  segment_self_color = segment_default_color,
+                                  segment_sibling_color = segment_default_color,
+                                  segment_spouse_color = segment_default_color,
+                                  segment_mz_color = segment_default_color,
+                                  segment_mz_linetype = 1,
+                                  segment_mz_alpha = 1,
+                                  segment_mz_t = .6,
+                                  segment_self_linetype = "dotdash",
+                                  segment_self_alpha = 0.5,
+                                  segment_self_angle = 90,
+                                  segment_self_curvature = -0.2,
+
+                                  # ---- Sex Legend and Appearance ----
+                                  sex_color_include = TRUE,
+                                  sex_legend_title = "Sex",
+                                  sex_shape_labels = c("Female", "Male", "Unknown"),
+                                  sex_color_palette = color_palette_default,
+                                  sex_shape_female = 16,
+                                  sex_shape_male = 15,
+                                  sex_shape_unknown = 18,
+
+                                  # ---- Affected Status Controls ----
+                                  status_include = TRUE,
+                                  status_code_affected = 1,
+                                  status_code_unaffected = 0,
+                                  status_label_affected = "Affected",
+                                  status_label_unaffected = "Unaffected",
+                                  status_alpha_affected = 1,
+                                  status_alpha_unaffected = 0,
+                                  status_color_palette = c(color_palette_default[1], color_palette_default[2]),
+                                  # Use first color for affected,
+                                  status_affected_shape = 4,
+                                  status_legend_title = "Affected",
+                                  status_legend_show = FALSE,
+
+                                  # ---- Focal Fill Settings ----
+                                  focal_fill_include = FALSE,
+                                  focal_fill_legend_show = TRUE,
+                                  focal_fill_personID = 1,
+                                  focal_fill_legend_title = "Focal Fill",
+                                  focal_fill_high_color = "#FDE725FF",
+                                  focal_fill_mid_color = "#9F2A63FF",
+                                  focal_fill_low_color = "#0D082AFF",
+                                  focal_fill_scale_midpoint = color_scale_midpoint,
+                                  focal_fill_method = "gradient",
+                                  focal_fill_component = "additive",
+                                  focal_fill_n_breaks = NULL,
+                                  focal_fill_na_value = "black",
+                                  focal_fill_force_zero = FALSE, # work around that sets zero to NA so you can distinguish from low values
+
+                                  # ---- Confidence Intervals
+                                  ci_include = TRUE,
+                                  ci_ribbon_alpha = .3,
+                                  # ---- matrix settings ----
+                                  matrix_sparse = FALSE,
+                                  matrix_isChild_method = "partialparent",
+                                  # -- Output Options ----
+                                  return_static = TRUE,
+                                  return_widget = FALSE,
+                                  return_interactive = FALSE,
+                                  # ---- Debugging Options ----
+                                  override_many2many = FALSE,
                                  ...) {
   # Ensure the color palette is a character vector
   if (!is.character(color_palette_default) ||
@@ -38,154 +290,153 @@ getDefaultPlotConfig <- function(color_palette_default =
 
   core_list <- list(
     # ---- General Appearance ----
-    apply_default_scales = TRUE,
-    apply_default_theme = TRUE,
+    apply_default_scales = apply_default_scales,
+    apply_default_theme = apply_default_theme,
     color_palette_default = color_palette_default,
-    color_palette_low = "#000004FF",
-    color_palette_mid = "#56106EFF",
-    color_palette_high = "#FCFDBFFF",
+    color_palette_low = color_palette_low,
+    color_palette_mid = color_palette_mid,
+    color_palette_high = color_palette_high,
     color_scale_midpoint = color_scale_midpoint,
-    color_scale = "ggthemes::calc", # only used in gg
-    alpha = alpha_default,
-    plot_title = NULL,
-    plot_subtitle = NULL,
-    value_rounding_digits = 2,
+    color_scale = color_scale, # only used in gg
+    alpha = alpha,
+    plot_title = plot_title,
+    plot_subtitle = plot_subtitle,
+    value_rounding_digits = value_rounding_digits,
     # --- SEX ------------------------------------------------------------
-    code_male = 1,
+    code_male = code_male,
 
     # ---- Filtering and Computation ----
-    filter_n_pairs = 500,
-    filter_degree_min = 0,
-    filter_degree_max = 7,
-    drop_classic_kin = FALSE,
-    drop_non_classic_sibs = TRUE,
-    use_only_classic_kin = TRUE,
-    use_relative_degree = TRUE,
-    group_by_kin = TRUE,
+    filter_n_pairs = filter_n_pairs,
+    filter_degree_min = filter_degree_min,
+    filter_degree_max = filter_degree_max,
+    drop_classic_kin = drop_classic_kin,
+    drop_non_classic_sibs = drop_non_classic_sibs,
+    use_only_classic_kin = use_only_classic_kin,
+    use_relative_degree = use_relative_degree,
+    group_by_kin = group_by_kin,
 
     # ----Kinbin Settings ----
-    match_threshold_percent = 10,
-    max_degree_levels = 12,
-    grouping_column = "mtdna_factor",
-
+    match_threshold_percent = match_threshold_percent,
+    max_degree_levels = max_degree_levels,
+    grouping_column = grouping_column,
 
     # ---- Annotation Settings ----
-    annotate_include = TRUE,
-    annotate_x_shift = -0.1,
-    annotate_y_shift = 0.005,
+    annotate_include = annotate_include,
+    annotate_x_shift = annotate_x_shift,
+    annotate_y_shift = annotate_y_shift,
 
     # ---- Label Aesthetics ----
-    label_include = TRUE,
-    label_column = "personID",
-    label_method = "ggrepel",
-    label_max_overlaps = 15,
-    label_nudge_x = 0,
-    label_nudge_y = -0.10,
-    label_segment_color = NA,
-    label_text_angle = 0,
-    label_text_size = 2,
-    label_text_color = "black",
+    label_include = label_include,
+    label_column = label_column,
+    label_method = label_method,
+    label_max_overlaps = label_max_overlaps,
+    label_nudge_x = label_nudge_x,
+    label_nudge_y = label_nudge_y,
+    label_segment_color = label_segment_color,
+    label_text_angle = label_text_angle,
+    label_text_size = label_text_size,
+    label_text_color = label_text_color,
 
     # --- POINT / OUTLINE AESTHETICS ---------------------------------------
-    point_size = 4,
-    outline_include = FALSE,
-    outline_multiplier = 1.25,
-    outline_color = "black",
+    point_size = point_size,
+    outline_include = outline_include,
+    outline_multiplier = outline_multiplier,
+    outline_color = outline_color,
 
 
     # ---- Tooltip Aesthetics ----
-    tooltip_include = TRUE,
-    tooltip_columns = c("ID1", "ID2", "value"),
+    tooltip_include = tooltip_include,
+    tooltip_columns = tooltip_columns,
 
     # ---- Axis and Layout Settings ----
-    axis_x_label = NULL,
-    axis_y_label = NULL,
-    axis_text_angle_x = 90,
-    axis_text_angle_y = 0,
-    axis_text_size = 8,
-    axis_text_color = "black",
+    axis_x_label = axis_x_label,
+    axis_y_label = axis_y_label,
+    axis_text_angle_x = axis_text_angle_x,
+    axis_text_angle_y = axis_text_angle_y,
+    axis_text_size = axis_text_size,
+    axis_text_color = axis_text_color,
 
     # ---- Generation Scale Settings ----
-    generation_height = 1,
-    generation_width = 1,
-    ped_packed = TRUE,
-    ped_align = TRUE,
-    ped_width = 15,
+    generation_height = generation_height,
+    generation_width = generation_width,
+    ped_packed = ped_packed,
+    ped_align = ped_align,
+    ped_width = ped_width,
 
     # ---- Segment Drawing Options ----
-    segment_linewidth = 0.5,
-    segment_linetype = 1,
-    segment_lineend = "round",
-    segment_linejoin = "round",
-    segment_offspring_color = segment_default_color,
-    segment_parent_color = segment_default_color,
-    segment_self_color = segment_default_color,
-    segment_sibling_color = segment_default_color,
-    segment_spouse_color = segment_default_color,
-    segment_mz_color = segment_default_color,
-    segment_mz_linetype = 1,
-    segment_mz_alpha = 1,
-    segment_mz_t = .6,
-    segment_self_linetype = "dotdash",
-    segment_self_alpha = 0.5,
-    segment_self_angle = 90,
-    segment_self_curvature = -0.2,
+    segment_linewidth = segment_linewidth,
+    segment_linetype = segment_linetype,
+    segment_lineend = segment_lineend,
+    segment_linejoin = segment_linejoin,
+    segment_offspring_color = segment_offspring_color,
+    segment_parent_color = segment_parent_color,
+    segment_self_color = segment_self_color,
+    segment_sibling_color = segment_sibling_color,
+    segment_spouse_color = segment_spouse_color,
+    segment_mz_color = segment_mz_color,
+    segment_mz_linetype = segment_mz_linetype,
+    segment_mz_alpha = segment_mz_alpha,
+    segment_mz_t = segment_mz_t,
+    segment_self_linetype = segment_self_linetype,
+    segment_self_alpha = segment_self_alpha,
+    segment_self_angle = segment_self_angle,
+    segment_self_curvature = segment_self_curvature,
 
     # ---- Sex Legend and Appearance ----
-    sex_color_include = TRUE,
-    sex_legend_title = "Sex",
-    sex_shape_labels = c("Female", "Male", "Unknown"),
-    sex_color_palette = color_palette_default,
-    sex_shape_female = 16,
-    sex_shape_male = 15,
-    sex_shape_unknown = 18,
+    sex_color_include = sex_color_include,
+    sex_legend_title = sex_legend_title,
+    sex_shape_labels = sex_shape_labels,
+    sex_color_palette = sex_color_palette,
+    sex_shape_female = sex_shape_female,
+    sex_shape_male = sex_shape_male,
+    sex_shape_unknown = sex_shape_unknown,
 
     # ---- Affected Status Controls ----
-    status_include = TRUE,
-    status_code_affected = 1,
-    status_code_unaffected = 0,
-    status_label_affected = "Affected",
-    status_label_unaffected = "Unaffected",
-    status_alpha_affected = 1,
-    status_alpha_unaffected = 0,
-    status_color_palette = c(color_palette_default[1], color_palette_default[2]),
+    status_include = status_include,
+    status_code_affected = status_code_affected,
+    status_code_unaffected = status_code_unaffected,
+    status_label_affected = status_label_affected,
+    status_label_unaffected = status_label_unaffected,
+    status_alpha_affected = status_alpha_affected,
+    status_alpha_unaffected = status_alpha_unaffected,
+    status_color_palette = status_color_palette,
     # Use first color for affected,
-    status_affected_shape = 4,
-    status_legend_title = "Affected",
-    status_legend_show = FALSE,
+    status_affected_shape = status_affected_shape,
+    status_legend_title = status_legend_title,
+    status_legend_show = status_legend_show,
 
     # ---- Focal Fill Settings ----
-    focal_fill_include = FALSE,
-    focal_fill_legend_show = TRUE,
-    focal_fill_personID = 1,
-    focal_fill_legend_title = "Focal Fill",
-    focal_fill_high_color = "#FDE725FF",
-    focal_fill_mid_color = "#9F2A63FF",
-    focal_fill_low_color = "#0D082AFF",
-    focal_fill_scale_midpoint = color_scale_midpoint,
-    focal_fill_method = "gradient",
-    focal_fill_component = "additive",
-    focal_fill_n_breaks = NULL,
-    focal_fill_na_value = "black",
-    focal_fill_force_zero = FALSE, # work around that sets zero to NA so you can distinguish from low values
+    focal_fill_include = focal_fill_include,
+    focal_fill_legend_show = focal_fill_legend_show,
+    focal_fill_personID = focal_fill_personID,
+    focal_fill_legend_title = focal_fill_legend_title,
+    focal_fill_high_color = focal_fill_high_color,
+    focal_fill_mid_color = focal_fill_mid_color,
+    focal_fill_low_color = focal_fill_low_color,
+    focal_fill_scale_midpoint = focal_fill_scale_midpoint,
+    focal_fill_method = focal_fill_method,
+    focal_fill_component = focal_fill_component,
+    focal_fill_n_breaks = focal_fill_n_breaks,
+    focal_fill_na_value = focal_fill_na_value,
+    focal_fill_force_zero = focal_fill_force_zero, # work around that sets zero to NA so you can distinguish from low values
 
     # ---- Confidence Intervals
 
-    ci_include = TRUE,
-    ci_ribbon_alpha = .3,
+    ci_include = ci_include,
+    ci_ribbon_alpha = ci_ribbon_alpha,
 
 
     # ---- matrix settings ----
-    matrix_sparse = FALSE,
-    matrix_isChild_method = "partialparent",
+    matrix_sparse = matrix_sparse,
+    matrix_isChild_method = matrix_isChild_method,
 
 
     # -- Output Options ----
-    return_static = TRUE,
-    return_widget = FALSE,
-    return_interactive = FALSE,
+    return_static = return_static,
+    return_widget = return_widget,
+    return_interactive = return_interactive,
     # ---- Debugging Options ----
-    override_many2many = FALSE
+    override_many2many = override_many2many
   )
 
   if (stringr::str_to_lower(function_name) %in% c("ggrelatednessmatrix")) {
@@ -196,6 +447,9 @@ getDefaultPlotConfig <- function(color_palette_default =
 
     core_list$point_size <-  1
     core_list$plot_title <- "Phenotypic Correlation vs Genetic Relatedness"
+    core_list$return_static <- FALSE
+    core_list$return_widget <- FALSE
+    core_list$return_interactive <- FALSE
 
   }
   if (stringr::str_to_lower(function_name) %in% c("ggpedigree", "ggpedigreeinteractive")) {

--- a/R/defaultPlotConfig.R
+++ b/R/defaultPlotConfig.R
@@ -18,6 +18,7 @@ getDefaultPlotConfig <- function(color_palette_default =
                                  function_name = "getDefaultPlotConfig",
                                  personID = "personID",
                                  color_scale_midpoint = 0.50,
+                                 alpha_default = 1,
                                  status_column = NULL,
                                  ...) {
   # Ensure the color palette is a character vector
@@ -31,7 +32,7 @@ getDefaultPlotConfig <- function(color_palette_default =
   }
 
 
-  if (!stringr::str_to_lower(function_name) %in% c("ggrelatednessmatrix", "ggpedigree", "ggpedigreeinteractive", "getdefaultplotconfig")) {
+  if (!stringr::str_to_lower(function_name) %in% c("ggrelatednessmatrix", "ggpedigree", "ggphenotypebydegree", "ggpedigreeinteractive", "getdefaultplotconfig")) {
     stop(paste0("The function ", function_name, " is not supported by getDefaultPlotConfig."))
   }
 
@@ -44,6 +45,8 @@ getDefaultPlotConfig <- function(color_palette_default =
     color_palette_mid = "#56106EFF",
     color_palette_high = "#FCFDBFFF",
     color_scale_midpoint = color_scale_midpoint,
+    color_scale = "ggthemes::calc", # only used in gg
+    alpha = alpha_default,
     plot_title = NULL,
     plot_subtitle = NULL,
     value_rounding_digits = 2,
@@ -56,8 +59,9 @@ getDefaultPlotConfig <- function(color_palette_default =
     filter_degree_max = 7,
     drop_classic_kin = FALSE,
     drop_non_classic_sibs = TRUE,
-    only_classic_kin = TRUE,
+    use_only_classic_kin = TRUE,
     use_relative_degree = TRUE,
+    group_by_kin = TRUE,
 
     # ----Kinbin Settings ----
     match_threshold_percent = 10,
@@ -87,6 +91,7 @@ getDefaultPlotConfig <- function(color_palette_default =
     outline_include = FALSE,
     outline_multiplier = 1.25,
     outline_color = "black",
+
 
     # ---- Tooltip Aesthetics ----
     tooltip_include = TRUE,
@@ -163,9 +168,18 @@ getDefaultPlotConfig <- function(color_palette_default =
     focal_fill_n_breaks = NULL,
     focal_fill_na_value = "black",
     focal_fill_force_zero = FALSE, # work around that sets zero to NA so you can distinguish from low values
+
+    # ---- Confidence Intervals
+
+    ci_include = TRUE,
+    ci_ribbon_alpha = .3,
+
+
     # ---- matrix settings ----
     matrix_sparse = FALSE,
     matrix_isChild_method = "partialparent",
+
+
     # -- Output Options ----
     return_static = TRUE,
     return_widget = FALSE,
@@ -177,6 +191,12 @@ getDefaultPlotConfig <- function(color_palette_default =
   if (stringr::str_to_lower(function_name) %in% c("ggrelatednessmatrix")) {
     #   If the function is ggRelatednessMatrix, we need to adjust the tooltip columns
     core_list$tooltip_columns <- c("ID1", "ID2", "value")
+  } else if (stringr::str_to_lower(function_name) %in%
+        c("ggphenotypebydegree", "phenotypebydegree")) {
+
+    core_list$point_size <-  1
+    core_list$plot_title <- "Phenotypic Correlation vs Genetic Relatedness"
+
   }
   if (stringr::str_to_lower(function_name) %in% c("ggpedigree", "ggpedigreeinteractive")) {
     core_list$label_method <- "ggrepel"
@@ -264,7 +284,12 @@ buildPlotConfig <- function(default_config,
       ),
       built_config$status_labs
     )
+  } else if(stringr::str_to_lower(function_name) %in%
+            c("ggphenotypebydegree", "phenotypebydegree")) {
+
+
   }
+
   return(built_config)
 }
 # -----

--- a/R/defaultPlotConfig.R
+++ b/R/defaultPlotConfig.R
@@ -125,155 +125,140 @@
 #' @export
 
 
-getDefaultPlotConfig <- function( function_name = "getDefaultPlotConfig",
-                                   personID = "personID",
-                                   status_column = NULL,
-                                   alpha_default = 1,
-                                  # ---- General Appearance ----
-                                  apply_default_scales = TRUE,
-                                  apply_default_theme = TRUE,
-                                  segment_default_color = "black",
-                                  color_palette_default = c("#440154FF", "#FDE725FF", "#21908CFF"),
-                                  color_palette_low = "#000004FF",
-                                  color_palette_mid = "#56106EFF",
-                                  color_palette_high = "#FCFDBFFF",
-                                  color_scale_midpoint = 0.50,
-                                  color_scale = "ggthemes::calc", # only used in gg
-                                  alpha = alpha_default,
-                                  plot_title = NULL,
-                                  plot_subtitle = NULL,
-                                  value_rounding_digits = 2,
-                                  # --- SEX ------------------------------------------------------------
-                                  code_male = 1,
-
-                                  # ---- Filtering and Computation ----
-                                  filter_n_pairs = 500,
-                                  filter_degree_min = 0,
-                                  filter_degree_max = 7,
-                                  drop_classic_kin = FALSE,
-                                  drop_non_classic_sibs = TRUE,
-                                  use_only_classic_kin = TRUE,
-                                  use_relative_degree = TRUE,
-                                  group_by_kin = TRUE,
-
-                                  # ----Kinbin Settings ----
-                                  match_threshold_percent = 10,
-                                  max_degree_levels = 12,
-                                  grouping_column = "mtdna_factor",
-
-
-                                  # ---- Annotation Settings ----
-                                  annotate_include = TRUE,
-                                  annotate_x_shift = -0.1,
-                                  annotate_y_shift = 0.005,
-
-                                  # ---- Label Aesthetics ----
-                                  label_include = TRUE,
-                                  label_column = "personID",
-                                  label_method = "ggrepel",
-                                  label_max_overlaps = 15,
-                                  label_nudge_x = 0,
-                                  label_nudge_y = -0.10,
-                                  label_segment_color = NA,
-                                  label_text_angle = 0,
-                                  label_text_size = 2,
-                                  label_text_color = "black",
-
-                                  # --- POINT / OUTLINE AESTHETICS ---------------------------------------
-                                  point_size = 4,
-                                  outline_include = FALSE,
-                                  outline_multiplier = 1.25,
-                                  outline_color = "black",
-
-
-                                  # ---- Tooltip Aesthetics ----
-                                  tooltip_include = TRUE,
-                                  tooltip_columns = c("ID1", "ID2", "value"),
-
-                                  # ---- Axis and Layout Settings ----
-                                  axis_x_label = NULL,
-                                  axis_y_label = NULL,
-                                  axis_text_angle_x = 90,
-                                  axis_text_angle_y = 0,
-                                  axis_text_size = 8,
-                                  axis_text_color = "black",
-
-                                  # ---- Generation Scale Settings ----
-                                  generation_height = 1,
-                                  generation_width = 1,
-                                  ped_packed = TRUE,
-                                  ped_align = TRUE,
-                                  ped_width = 15,
-
-                                  # ---- Segment Drawing Options ----
-                                  segment_linewidth = 0.5,
-                                  segment_linetype = 1,
-                                  segment_lineend = "round",
-                                  segment_linejoin = "round",
-                                  segment_offspring_color = segment_default_color,
-                                  segment_parent_color = segment_default_color,
-                                  segment_self_color = segment_default_color,
-                                  segment_sibling_color = segment_default_color,
-                                  segment_spouse_color = segment_default_color,
-                                  segment_mz_color = segment_default_color,
-                                  segment_mz_linetype = 1,
-                                  segment_mz_alpha = 1,
-                                  segment_mz_t = .6,
-                                  segment_self_linetype = "dotdash",
-                                  segment_self_alpha = 0.5,
-                                  segment_self_angle = 90,
-                                  segment_self_curvature = -0.2,
-
-                                  # ---- Sex Legend and Appearance ----
-                                  sex_color_include = TRUE,
-                                  sex_legend_title = "Sex",
-                                  sex_shape_labels = c("Female", "Male", "Unknown"),
-                                  sex_color_palette = color_palette_default,
-                                  sex_shape_female = 16,
-                                  sex_shape_male = 15,
-                                  sex_shape_unknown = 18,
-
-                                  # ---- Affected Status Controls ----
-                                  status_include = TRUE,
-                                  status_code_affected = 1,
-                                  status_code_unaffected = 0,
-                                  status_label_affected = "Affected",
-                                  status_label_unaffected = "Unaffected",
-                                  status_alpha_affected = 1,
-                                  status_alpha_unaffected = 0,
-                                  status_color_palette = c(color_palette_default[1], color_palette_default[2]),
-                                  # Use first color for affected,
-                                  status_affected_shape = 4,
-                                  status_legend_title = "Affected",
-                                  status_legend_show = FALSE,
-
-                                  # ---- Focal Fill Settings ----
-                                  focal_fill_include = FALSE,
-                                  focal_fill_legend_show = TRUE,
-                                  focal_fill_personID = 1,
-                                  focal_fill_legend_title = "Focal Fill",
-                                  focal_fill_high_color = "#FDE725FF",
-                                  focal_fill_mid_color = "#9F2A63FF",
-                                  focal_fill_low_color = "#0D082AFF",
-                                  focal_fill_scale_midpoint = color_scale_midpoint,
-                                  focal_fill_method = "gradient",
-                                  focal_fill_component = "additive",
-                                  focal_fill_n_breaks = NULL,
-                                  focal_fill_na_value = "black",
-                                  focal_fill_force_zero = FALSE, # work around that sets zero to NA so you can distinguish from low values
-
-                                  # ---- Confidence Intervals
-                                  ci_include = TRUE,
-                                  ci_ribbon_alpha = .3,
-                                  # ---- matrix settings ----
-                                  matrix_sparse = FALSE,
-                                  matrix_isChild_method = "partialparent",
-                                  # -- Output Options ----
-                                  return_static = TRUE,
-                                  return_widget = FALSE,
-                                  return_interactive = FALSE,
-                                  # ---- Debugging Options ----
-                                  override_many2many = FALSE,
+getDefaultPlotConfig <- function(function_name = "getDefaultPlotConfig",
+                                 personID = "personID",
+                                 status_column = NULL,
+                                 alpha_default = 1,
+                                 # ---- General Appearance ----
+                                 apply_default_scales = TRUE,
+                                 apply_default_theme = TRUE,
+                                 segment_default_color = "black",
+                                 color_palette_default = c("#440154FF", "#FDE725FF", "#21908CFF"),
+                                 color_palette_low = "#000004FF",
+                                 color_palette_mid = "#56106EFF",
+                                 color_palette_high = "#FCFDBFFF",
+                                 color_scale_midpoint = 0.50,
+                                 color_scale = "ggthemes::calc", # only used in gg
+                                 alpha = alpha_default,
+                                 plot_title = NULL,
+                                 plot_subtitle = NULL,
+                                 value_rounding_digits = 2,
+                                 # --- SEX ------------------------------------------------------------
+                                 code_male = 1,
+                                 # ---- Filtering and Computation ----
+                                 filter_n_pairs = 500,
+                                 filter_degree_min = 0,
+                                 filter_degree_max = 7,
+                                 drop_classic_kin = FALSE,
+                                 drop_non_classic_sibs = TRUE,
+                                 use_only_classic_kin = TRUE,
+                                 use_relative_degree = TRUE,
+                                 group_by_kin = TRUE,
+                                 # ----Kinbin Settings ----
+                                 match_threshold_percent = 10,
+                                 max_degree_levels = 12,
+                                 grouping_column = "mtdna_factor",
+                                 # ---- Annotation Settings ----
+                                 annotate_include = TRUE,
+                                 annotate_x_shift = -0.1,
+                                 annotate_y_shift = 0.005,
+                                 # ---- Label Aesthetics ----
+                                 label_include = TRUE,
+                                 label_column = "personID",
+                                 label_method = "ggrepel",
+                                 label_max_overlaps = 15,
+                                 label_nudge_x = 0,
+                                 label_nudge_y = -0.10,
+                                 label_segment_color = NA,
+                                 label_text_angle = 0,
+                                 label_text_size = 2,
+                                 label_text_color = "black",
+                                 # --- POINT / OUTLINE AESTHETICS ---------------------------------------
+                                 point_size = 4,
+                                 outline_include = FALSE,
+                                 outline_multiplier = 1.25,
+                                 outline_color = "black",
+                                 # ---- Tooltip Aesthetics ----
+                                 tooltip_include = TRUE,
+                                 tooltip_columns = c("ID1", "ID2", "value"),
+                                 # ---- Axis and Layout Settings ----
+                                 axis_x_label = NULL,
+                                 axis_y_label = NULL,
+                                 axis_text_angle_x = 90,
+                                 axis_text_angle_y = 0,
+                                 axis_text_size = 8,
+                                 axis_text_color = "black",
+                                 # ---- Generation Scale Settings ----
+                                 generation_height = 1,
+                                 generation_width = 1,
+                                 ped_packed = TRUE,
+                                 ped_align = TRUE,
+                                 ped_width = 15,
+                                 # ---- Segment Drawing Options ----
+                                 segment_linewidth = 0.5,
+                                 segment_linetype = 1,
+                                 segment_lineend = "round",
+                                 segment_linejoin = "round",
+                                 segment_offspring_color = segment_default_color,
+                                 segment_parent_color = segment_default_color,
+                                 segment_self_color = segment_default_color,
+                                 segment_sibling_color = segment_default_color,
+                                 segment_spouse_color = segment_default_color,
+                                 segment_mz_color = segment_default_color,
+                                 segment_mz_linetype = 1,
+                                 segment_mz_alpha = 1,
+                                 segment_mz_t = .6,
+                                 segment_self_linetype = "dotdash",
+                                 segment_self_alpha = 0.5,
+                                 segment_self_angle = 90,
+                                 segment_self_curvature = -0.2,
+                                 # ---- Sex Legend and Appearance ----
+                                 sex_color_include = TRUE,
+                                 sex_legend_title = "Sex",
+                                 sex_shape_labels = c("Female", "Male", "Unknown"),
+                                 sex_color_palette = color_palette_default,
+                                 sex_shape_female = 16,
+                                 sex_shape_male = 15,
+                                 sex_shape_unknown = 18,
+                                 # ---- Affected Status Controls ----
+                                 status_include = TRUE,
+                                 status_code_affected = 1,
+                                 status_code_unaffected = 0,
+                                 status_label_affected = "Affected",
+                                 status_label_unaffected = "Unaffected",
+                                 status_alpha_affected = 1,
+                                 status_alpha_unaffected = 0,
+                                 status_color_palette = c(color_palette_default[1], color_palette_default[2]),
+                                 # Use first color for affected,
+                                 status_affected_shape = 4,
+                                 status_legend_title = "Affected",
+                                 status_legend_show = FALSE,
+                                 # ---- Focal Fill Settings ----
+                                 focal_fill_include = FALSE,
+                                 focal_fill_legend_show = TRUE,
+                                 focal_fill_personID = 1,
+                                 focal_fill_legend_title = "Focal Fill",
+                                 focal_fill_high_color = "#FDE725FF",
+                                 focal_fill_mid_color = "#9F2A63FF",
+                                 focal_fill_low_color = "#0D082AFF",
+                                 focal_fill_scale_midpoint = color_scale_midpoint,
+                                 focal_fill_method = "gradient",
+                                 focal_fill_component = "additive",
+                                 focal_fill_n_breaks = NULL,
+                                 focal_fill_na_value = "black",
+                                 focal_fill_force_zero = FALSE, # work around that sets zero to NA so you can distinguish from low values
+                                 # ---- Confidence Intervals
+                                 ci_include = TRUE,
+                                 ci_ribbon_alpha = .3,
+                                 # ---- matrix settings ----
+                                 matrix_sparse = FALSE,
+                                 matrix_isChild_method = "partialparent",
+                                 # -- Output Options ----
+                                 return_static = TRUE,
+                                 return_widget = FALSE,
+                                 return_interactive = FALSE,
+                                 # ---- Debugging Options ----
+                                 override_many2many = FALSE,
                                  ...) {
   # Ensure the color palette is a character vector
   if (!is.character(color_palette_default) ||
@@ -445,14 +430,12 @@ getDefaultPlotConfig <- function( function_name = "getDefaultPlotConfig",
     #   If the function is ggRelatednessMatrix, we need to adjust the tooltip columns
     core_list$tooltip_columns <- c("ID1", "ID2", "value")
   } else if (stringr::str_to_lower(function_name) %in%
-        c("ggphenotypebydegree", "phenotypebydegree")) {
-
-    core_list$point_size <-  1
+    c("ggphenotypebydegree", "phenotypebydegree")) {
+    core_list$point_size <- 1
     core_list$plot_title <- "Phenotypic Correlation vs Genetic Relatedness"
     core_list$return_static <- FALSE
     core_list$return_widget <- FALSE
     core_list$return_interactive <- FALSE
-
   }
   if (stringr::str_to_lower(function_name) %in% c("ggpedigree", "ggpedigreeinteractive")) {
     core_list$label_method <- "ggrepel"
@@ -540,8 +523,8 @@ buildPlotConfig <- function(default_config,
       ),
       built_config$status_labs
     )
-  } else if(stringr::str_to_lower(function_name) %in%
-            c("ggphenotypebydegree", "phenotypebydegree")) {
+  } else if (stringr::str_to_lower(function_name) %in%
+    c("ggphenotypebydegree", "phenotypebydegree")) {
 
 
   }

--- a/R/ggPhenotypeByDegree.R
+++ b/R/ggPhenotypeByDegree.R
@@ -83,36 +83,36 @@ ggPhenotypeByDegree <- function(df,
   )
 
   # Set default styling and layout parameters
-#  default_config <- list(
-#    apply_default_scales = TRUE,
-#    apply_default_theme = TRUE,
- #   point_size = 1,
-#    ci_ribbon_alpha = 0.3,
+  #  default_config <- list(
+  #    apply_default_scales = TRUE,
+  #    apply_default_theme = TRUE,
+  #   point_size = 1,
+  #    ci_ribbon_alpha = 0.3,
 
-    # Filter parameters
- #   filter_n_pairs = 500,
+  # Filter parameters
+  #   filter_n_pairs = 500,
   #  filter_degree_min = 0,
   #  filter_degree_max = 7,
-    # Plotting parameters
-#    plot_title = "Phenotypic Correlation vs Genetic Relatedness",
-#    subtitle = NULL,
-#    color_scale = "ggthemes::calc",
+  # Plotting parameters
+  #    plot_title = "Phenotypic Correlation vs Genetic Relatedness",
+  #    subtitle = NULL,
+  #    color_scale = "ggthemes::calc",
 
-    # Configuration parameters
- #   use_only_classic_kin = TRUE,
+  # Configuration parameters
+  #   use_only_classic_kin = TRUE,
   #  group_by_kin = TRUE,
- #   drop_classic_kin = FALSE,
+  #   drop_classic_kin = FALSE,
   #  drop_non_classic_sibs = TRUE,
-    # Annotation parameters
+  # Annotation parameters
 
 
-    # Grouping and scaling parameters
+  # Grouping and scaling parameters
   #  use_relative_degree = TRUE,
- #   grouping_column = "mtdna_factor",
-#    value_rounding_digits = 2,
- #   match_threshold_percent = 10,
-#    max_degree_levels = 12
-#  )
+  #   grouping_column = "mtdna_factor",
+  #    value_rounding_digits = 2,
+  #   match_threshold_percent = 10,
+  #    max_degree_levels = 12
+  #  )
 
   # Merge user config with defaults
   config <- utils::modifyList(default_config, config)

--- a/R/ggPhenotypeByDegree.R
+++ b/R/ggPhenotypeByDegree.R
@@ -24,22 +24,22 @@ utils::globalVariables(c(".x"))
 #'     \item{filter_n_pairs}{Minimum number of pairs to include (default: 500)}
 #'     \item{filter_degree_min}{Minimum degree of relatedness (default: 0)}
 #'     \item{filter_degree_max}{Maximum degree of relatedness (default: 7)}
-#'     \item{title}{Plot title}
-#'     \item{subtitle}{Plot subtitle}
+#'     \item{plot_title}{Plot title}
+#'     \item{plot_subtitle}{Plot subtitle}
 #'     \item{color_scale}{Paletteer color scale name (e.g., "ggthemes::calc")}
-#'     \item{only_classic_kin}{If TRUE, only classic kin are shown}
-#'     \item{kin_grouping}{If TRUE, use classic kin × mtDNA for grouping}
+#'     \item{use_only_classic_kin}{If TRUE, only classic kin are shown}
+#'     \item{group_by_kin}{If TRUE, use classic kin × mtDNA for grouping}
 #'     \item{drop_classic_kin}{If TRUE, remove classic kin rows}
 #'     \item{drop_non_classic_sibs}{If TRUE, remove non-classic sibs (default: TRUE)}
-#'     \item{annotate}{If TRUE, annotate mother/father/sibling points}
-#'     \item{annotate_xshift}{Relative x-axis shift for annotations}
-#'     \item{annotate_yshift}{Relative y-axis shift for annotations}
+#'     \item{annotate_include}{If TRUE, annotate mother/father/sibling points}
+#'     \item{annotate_x_shift}{Relative x-axis shift for annotations}
+#'     \item{annotate_y_shift}{Relative y-axis shift for annotations}
 #'     \item{point_size}{Size of geom_point points (default: 1)}
-#'     \item{degree_rel}{If TRUE, x-axis uses degree-of-relatedness scaling}
-#'     \item{grouping}{Grouping column name (default: mtdna_factor)}
-#'     \item{rounding}{Number of decimal places for rounding (default: 2)}
-#'     \item{threshold}{Tolerance \% for matching known degrees}
-#'     \item{max_degrees}{Maximum number of degrees to consider}
+#'     \item{use_relative_degree}{If TRUE, x-axis uses degree-of-relatedness scaling}
+#'     \item{grouping_column}{Grouping column name (default: mtdna_factor)}
+#'     \item{value_rounding_digits}{Number of decimal places for rounding (default: 2)}
+#'     \item{match_threshold_percent}{Tolerance \% for matching known degrees}
+#'     \item{max_degree_levels}{Maximum number of degrees to consider}
 #' }
 #'
 #' @return A ggplot object containing the correlation plot.
@@ -69,40 +69,50 @@ ggPhenotypeByDegree <- function(df,
     y_stem_se <- sub("_se$", "", y_se)
   }
 
+  # Set default styling and layout parameters
+  default_config <- getDefaultPlotConfig(
+    function_name = "ggphenotypebydegree",
+  )
+
+  # Merge with user-specified overrides
+  # This allows the user to override any of the default values
+  config <- buildPlotConfig(
+    default_config = default_config,
+    config = config,
+    function_name = "ggphenotypebydegree"
+  )
 
   # Set default styling and layout parameters
-  default_config <- list(
-    apply_default_scales = TRUE,
-    apply_default_theme = TRUE,
-    point_size = 1,
-    ribbon_alpha = 0.3,
+#  default_config <- list(
+#    apply_default_scales = TRUE,
+#    apply_default_theme = TRUE,
+ #   point_size = 1,
+#    ci_ribbon_alpha = 0.3,
 
     # Filter parameters
-    filter_n_pairs = 500,
-    filter_degree_min = 0,
-    filter_degree_max = 7,
+ #   filter_n_pairs = 500,
+  #  filter_degree_min = 0,
+  #  filter_degree_max = 7,
     # Plotting parameters
-    title = "Phenotypic Correlation vs Genetic Relatedness",
-    subtitle = NULL,
-    color_scale = "ggthemes::calc",
+#    plot_title = "Phenotypic Correlation vs Genetic Relatedness",
+#    subtitle = NULL,
+#    color_scale = "ggthemes::calc",
 
     # Configuration parameters
-    only_classic_kin = TRUE,
-    kin_grouping = TRUE,
-    drop_classic_kin = FALSE,
-    drop_non_classic_sibs = TRUE,
+ #   use_only_classic_kin = TRUE,
+  #  group_by_kin = TRUE,
+ #   drop_classic_kin = FALSE,
+  #  drop_non_classic_sibs = TRUE,
     # Annotation parameters
-    annotate = TRUE,
-    annotate_xshift = -0.1,
-    annotate_yshift = 0.005,
+
 
     # Grouping and scaling parameters
-    degree_rel = TRUE,
-    grouping = "mtdna_factor",
-    rounding = 2,
-    threshold = 10,
-    max_degrees = 12
-  )
+  #  use_relative_degree = TRUE,
+ #   grouping_column = "mtdna_factor",
+#    value_rounding_digits = 2,
+ #   match_threshold_percent = 10,
+#    max_degree_levels = 12
+#  )
 
   # Merge user config with defaults
   config <- utils::modifyList(default_config, config)
@@ -157,17 +167,17 @@ ggPhenotypeByDegree.core <- function(df,
     ymin_var <- rlang::sym(paste0(y_stem_se, "_minusse"))
     ymax_var <- rlang::sym(paste0(y_stem_se, "_plusse"))
   }
-  if (config$grouping == "mtdna_factor") {
+  if (config$grouping_column == "mtdna_factor") {
     config$grouping_name <- "mtDNA"
   } else {
-    config$grouping_name <- paste0(config$grouping)
+    config$grouping_name <- paste0(config$grouping_column)
   }
-  grouping_sym <- rlang::sym(config$grouping)
+  grouping_sym <- rlang::sym(config$grouping_column)
 
   # ---- Prepare annotations plotting ----
   # Extract specific y-values based on provided positions, using dynamic column names
 
-  if (config$annotate == TRUE) {
+  if (config$annotate_include == TRUE) {
     config$annotation_coords <- list(x_sib = 0.5, x_mom = 0.5, x_dad = 0.5)
     y_val_coord <- function(filter_expr) {
       df |>
@@ -178,12 +188,12 @@ ggPhenotypeByDegree.core <- function(df,
     config$annotation_coords$y_sib <- y_val_coord(".data$cnu == 1 & .data$addRel_center == 0.5")
     config$annotation_coords$y_mom <- y_val_coord(".data$cnu == 0 & .data$mtdna == 1 & .data$addRel_center == 0.5")
     config$annotation_coords$y_dad <- y_val_coord(".data$cnu == 0 & .data$mtdna == 0 & .data$addRel_center == 0.5")
-    config$annotation_coords$annotation_mom_x <- config$annotation_coords$x_mom + config$annotate_xshift * config$annotation_coords$x_mom
-    config$annotation_coords$annotation_sib_x <- config$annotation_coords$x_sib + config$annotate_xshift * config$annotation_coords$x_sib
-    config$annotation_coords$annotation_dad_x <- config$annotation_coords$x_dad + config$annotate_xshift * config$annotation_coords$x_dad
-    config$annotation_coords$annotation_sib_y <- config$annotation_coords$y_sib + config$annotate_yshift * config$annotation_coords$y_sib
-    config$annotation_coords$annotation_mom_y <- config$annotation_coords$y_mom + config$annotate_yshift * config$annotation_coords$y_mom
-    config$annotation_coords$annotation_dad_y <- config$annotation_coords$y_dad + config$annotate_yshift * config$annotation_coords$y_dad
+    config$annotation_coords$annotation_mom_x <- config$annotation_coords$x_mom + config$annotate_x_shift * config$annotation_coords$x_mom
+    config$annotation_coords$annotation_sib_x <- config$annotation_coords$x_sib + config$annotate_x_shift * config$annotation_coords$x_sib
+    config$annotation_coords$annotation_dad_x <- config$annotation_coords$x_dad + config$annotate_x_shift * config$annotation_coords$x_dad
+    config$annotation_coords$annotation_sib_y <- config$annotation_coords$y_sib + config$annotate_y_shift * config$annotation_coords$y_sib
+    config$annotation_coords$annotation_mom_y <- config$annotation_coords$y_mom + config$annotate_y_shift * config$annotation_coords$y_mom
+    config$annotation_coords$annotation_dad_y <- config$annotation_coords$y_dad + config$annotate_y_shift * config$annotation_coords$y_dad
     config$annotation_coords$df_point <- df |> dplyr::filter(.data$cnu == 1, .data$addRel_center == .5)
   } else {
     config$annotation_coords <- NULL
@@ -205,8 +215,8 @@ ggPhenotypeByDegree.core <- function(df,
       dplyr::filter(.data$drop != 1) |>
       dplyr::select(-"drop")
   }
-  # if only_classic_kin is TRUE, filter out non-classic kinship
-  if (config$only_classic_kin == TRUE) {
+  # if use_only_classic_kin is TRUE, filter out non-classic kinship
+  if (config$use_only_classic_kin == TRUE) {
     df <- df |> dplyr::filter(.data$classic_kin == 1)
   } else if (config$drop_classic_kin == TRUE) {
     df <- df |> dplyr::filter(.data$classic_kin == 0)
@@ -222,7 +232,7 @@ ggPhenotypeByDegree.core <- function(df,
       shape = !!grouping_sym
     ))
 
-  if (config$only_classic_kin == TRUE | config$kin_grouping == TRUE) {
+  if (config$use_only_classic_kin == TRUE | config$group_by_kin == TRUE) {
     core_plot <- core_plot +
       ggplot2::geom_ribbon(
         ggplot2::aes(
@@ -230,7 +240,7 @@ ggPhenotypeByDegree.core <- function(df,
           ymax = !!ymax_var,
           fill = !!grouping_sym
         ),
-        alpha = config$ribbon_alpha,
+        alpha = config$ci_ribbon_alpha,
         linetype = 0
       ) + # , stat = "smooth", method = "loess") +
       ggplot2::geom_line(ggplot2::aes(linetype = !!grouping_sym))
@@ -247,7 +257,7 @@ ggPhenotypeByDegree.core <- function(df,
         stat = "smooth", span = .02,
         outline.type = "upper",
         method = "lm", # group = df$classic_kin,
-        alpha = config$ribbon_alpha,
+        alpha = config$ci_ribbon_alpha,
         linetype = 0,
         show.legend = FALSE
       ) +
@@ -261,7 +271,7 @@ ggPhenotypeByDegree.core <- function(df,
     ggplot2::geom_point(size = config$point_size)
 
   # annotate if and only if
-  if (config$annotate == TRUE && config$filter_degree_min == 0) {
+  if (config$annotate_include == TRUE && config$filter_degree_min == 0) {
     core_plot <- .addAnnotate(
       p = core_plot,
       config = config,
@@ -279,7 +289,7 @@ ggPhenotypeByDegree.core <- function(df,
       ggplot2::theme(legend.position = "top") # scale_x_reverse() +
   }
 
-  if (config$degree_rel == TRUE) {
+  if (config$use_relative_degree == TRUE) {
     core_plot <- core_plot + scale_x_continuous(
       trans = scales::compose_trans("log2", "reverse"),
       breaks = scales::trans_breaks("log2", function(x) 2^x),
@@ -287,8 +297,9 @@ ggPhenotypeByDegree.core <- function(df,
     ) +
       labs(
         x = "Degree of Relatedness", y = "Correlation",
-        title = config$title,
-        subtitle = config$subtitle, color = config$grouping_name,
+        title = config$plot_title,
+        subtitle = config$plot_subtitle,
+        color = config$grouping_name,
         shape = config$grouping_name,
         linetype = config$grouping_name,
         group = config$grouping_name,
@@ -302,8 +313,8 @@ ggPhenotypeByDegree.core <- function(df,
     ) +
       labs(
         x = "Coefficient of Genetic Variation",
-        y = "Correlation", title = config$title,
-        subtitle = config$subtitle,
+        y = "Correlation", title = config$plot_title,
+        subtitle = config$plot_subtitle,
         color = config$grouping_name,
         shape = config$grouping_name,
         linetype = config$grouping_name,
@@ -355,7 +366,7 @@ ggPhenotypeByDegree.core <- function(df,
       dplyr::mutate(
         classic_kin =
           dplyr::case_when(
-            .data$addRel_max %in% (2^(0:(-config$max_degrees)) * (1 + config$threshold / 100)) ~ 1,
+            .data$addRel_max %in% (2^(0:(-config$max_degree_levels)) * (1 + config$match_threshold_percent / 100)) ~ 1,
             .data$addRel_max == 0 ~ 1,
             TRUE ~ 0
           )
@@ -366,8 +377,8 @@ ggPhenotypeByDegree.core <- function(df,
       dplyr::mutate(
         degree_relative = # solve for as a function of addRel_max
           dplyr::case_when(
-            .data$addRel_max >= (1 + config$threshold / 100) ~ 0,
-            .data$addRel_max < 1 ~ log2(1 / (.data$addRel_max) * (1 + config$threshold / 100))
+            .data$addRel_max >= (1 + config$match_threshold_percent / 100) ~ 0,
+            .data$addRel_max < 1 ~ log2(1 / (.data$addRel_max) * (1 + config$match_threshold_percent / 100))
           )
       )
   }

--- a/data-raw/scrap_icc.R
+++ b/data-raw/scrap_icc.R
@@ -1,0 +1,108 @@
+
+
+library(dplyr)
+library(tidyr)
+library(purrr)
+library(psych)
+
+result_lrs_icc_adjusted <- dataRelatedPair_merge %>%
+  # Stack both members' data into a long form: personID + trait value
+  select(addRel_factor, mitRel, cnuRel, ID1, ID2, lrs_k1, lrs_k2) %>%
+  pivot_longer(
+    cols = c(ID1, ID2, lrs_k1, lrs_k2),
+    names_to = c(".value", "k"),
+    names_pattern = "(ID|lrs)_(k[12])"
+  ) %>%
+  rename(personID = ID) %>%
+  filter(!is.na(lrs)) %>%
+  group_by(addRel_factor, mitRel, cnuRel) %>%
+  group_nest() %>%
+  mutate(
+    # Compute ICC(1) for each relatedness bin
+    icc = map_dbl(data, function(df) {
+      wide <- df %>%
+        group_by(personID) %>%
+        mutate(obs = row_number()) %>%
+        ungroup() %>%
+        pivot_wider(id_cols = personID, names_from = obs, values_from = lrs)
+
+      datamat <- wide %>% select(-personID)
+      datamat <- datamat[rowSums(!is.na(datamat)) > 1, , drop = FALSE]
+
+      if (nrow(datamat) >= 2) {
+        psych::ICC(datamat)$results %>%
+          filter(type == "ICC1") %>%
+          pull(ICC)
+      } else {
+        NA_real_
+      }
+    }),
+    # Compute average number of lrs observations per person
+    avg_m = map_dbl(data, ~ .x %>% count(personID) %>% summarise(mean(n)) %>% pull()),
+    # Join to your existing correlation results
+    .keep = "unused"
+  ) %>%
+  right_join(result, by = c("addRel_factor", "mitRel" = "mtdna", "cnuRel" = "cnu")) %>%
+  mutate(
+    se_lrs_raw = cor_lrs / cor_lrs_stat,
+    cor_lrs_se_adj = adjust_se_by_icc(se_lrs_raw, icc, avg_m),
+    cor_lrs_ci_lb_adj = cor_lrs - 1.96 * cor_lrs_se_adj,
+    cor_lrs_ci_ub_adj = cor_lrs + 1.96 * cor_lrs_se_adj
+  )
+
+compute_icc1_from_long <- function(df, person_col = "personID", value_col = "value") {
+  wide <- df %>%
+    filter(!is.na(.data[[value_col]])) %>%
+    group_by(.data[[person_col]]) %>%
+    mutate(obs = row_number()) %>%
+    ungroup() %>%
+    pivot_wider(
+      id_cols = .data[[person_col]],
+      names_from = obs,
+      values_from = .data[[value_col]]
+    )
+
+  datamat <- wide %>% select(-all_of(person_col))
+  datamat <- datamat[rowSums(!is.na(datamat)) > 1, , drop = FALSE]
+
+  if (nrow(datamat) >= 2) {
+    icc_out <- psych::ICC(datamat)
+    return(icc_out$results[icc_out$results$type == "ICC1", "ICC"])
+  } else {
+    return(NA_real_)
+  }
+}
+
+compute_avg_m_from_long <- function(df, person_col = "personID", value_col = "value") {
+  df %>%
+    filter(!is.na(.data[[value_col]])) %>%
+    count(.data[[person_col]]) %>%
+    summarise(avg_m = mean(n)) %>%
+    pull(avg_m)
+}
+adjust_se_by_icc <- function(se_raw, icc, avg_m) {
+  if (is.na(se_raw) || is.na(icc) || is.na(avg_m)) return(NA_real_)
+  design_effect <- 1 + (avg_m - 1) * icc
+  se_raw * sqrt(design_effect)
+}
+
+
+
+extract_person_trait_long <- function(df, trait) {
+  # Extracts personID and trait values from *_k1 and *_k2
+  id_col1 <- sym("ID1")
+  id_col2 <- sym("ID2")
+  trait_k1 <- sym(paste0(trait, "_k1"))
+  trait_k2 <- sym(paste0(trait, "_k2"))
+
+  df %>%
+    select(addRel_factor, mitRel, cnuRel, !!id_col1, !!id_col2, !!trait_k1, !!trait_k2) %>%
+    pivot_longer(
+      cols = c(!!id_col1, !!id_col2, !!trait_k1, !!trait_k2),
+      names_to = c(".value", "k"),
+      names_pattern = paste0("(", trait, "|ID)_(k[12])")
+    ) %>%
+    rename(personID = ID)
+}
+
+

--- a/data-raw/scrap_icc.R
+++ b/data-raw/scrap_icc.R
@@ -1,5 +1,3 @@
-
-
 library(dplyr)
 library(tidyr)
 library(purrr)
@@ -38,7 +36,10 @@ result_lrs_icc_adjusted <- dataRelatedPair_merge %>%
       }
     }),
     # Compute average number of lrs observations per person
-    avg_m = map_dbl(data, ~ .x %>% count(personID) %>% summarise(mean(n)) %>% pull()),
+    avg_m = map_dbl(data, ~ .x %>%
+      count(personID) %>%
+      summarise(mean(n)) %>%
+      pull()),
     # Join to your existing correlation results
     .keep = "unused"
   ) %>%
@@ -81,7 +82,9 @@ compute_avg_m_from_long <- function(df, person_col = "personID", value_col = "va
     pull(avg_m)
 }
 adjust_se_by_icc <- function(se_raw, icc, avg_m) {
-  if (is.na(se_raw) || is.na(icc) || is.na(avg_m)) return(NA_real_)
+  if (is.na(se_raw) || is.na(icc) || is.na(avg_m)) {
+    return(NA_real_)
+  }
   design_effect <- 1 + (avg_m - 1) * icc
   se_raw * sqrt(design_effect)
 }
@@ -104,5 +107,3 @@ extract_person_trait_long <- function(df, trait) {
     ) %>%
     rename(personID = ID)
 }
-
-

--- a/man/dot-addAnnotate.Rd
+++ b/man/dot-addAnnotate.Rd
@@ -12,22 +12,22 @@
     \item{filter_n_pairs}{Minimum number of pairs to include (default: 500)}
     \item{filter_degree_min}{Minimum degree of relatedness (default: 0)}
     \item{filter_degree_max}{Maximum degree of relatedness (default: 7)}
-    \item{title}{Plot title}
-    \item{subtitle}{Plot subtitle}
+    \item{plot_title}{Plot title}
+    \item{plot_subtitle}{Plot subtitle}
     \item{color_scale}{Paletteer color scale name (e.g., "ggthemes::calc")}
-    \item{only_classic_kin}{If TRUE, only classic kin are shown}
-    \item{kin_grouping}{If TRUE, use classic kin × mtDNA for grouping}
+    \item{use_only_classic_kin}{If TRUE, only classic kin are shown}
+    \item{group_by_kin}{If TRUE, use classic kin × mtDNA for grouping}
     \item{drop_classic_kin}{If TRUE, remove classic kin rows}
     \item{drop_non_classic_sibs}{If TRUE, remove non-classic sibs (default: TRUE)}
-    \item{annotate}{If TRUE, annotate mother/father/sibling points}
-    \item{annotate_xshift}{Relative x-axis shift for annotations}
-    \item{annotate_yshift}{Relative y-axis shift for annotations}
+    \item{annotate_include}{If TRUE, annotate mother/father/sibling points}
+    \item{annotate_x_shift}{Relative x-axis shift for annotations}
+    \item{annotate_y_shift}{Relative y-axis shift for annotations}
     \item{point_size}{Size of geom_point points (default: 1)}
-    \item{degree_rel}{If TRUE, x-axis uses degree-of-relatedness scaling}
-    \item{grouping}{Grouping column name (default: mtdna_factor)}
-    \item{rounding}{Number of decimal places for rounding (default: 2)}
-    \item{threshold}{Tolerance \% for matching known degrees}
-    \item{max_degrees}{Maximum number of degrees to consider}
+    \item{use_relative_degree}{If TRUE, x-axis uses degree-of-relatedness scaling}
+    \item{grouping_column}{Grouping column name (default: mtdna_factor)}
+    \item{value_rounding_digits}{Number of decimal places for rounding (default: 2)}
+    \item{match_threshold_percent}{Tolerance \% for matching known degrees}
+    \item{max_degree_levels}{Maximum number of degrees to consider}
 }}
 }
 \value{

--- a/man/dot-preparePhenotypeByDegreeData.Rd
+++ b/man/dot-preparePhenotypeByDegreeData.Rd
@@ -40,22 +40,22 @@ This function prepares the data frame for plotting by calculating necessary colu
     \item{filter_n_pairs}{Minimum number of pairs to include (default: 500)}
     \item{filter_degree_min}{Minimum degree of relatedness (default: 0)}
     \item{filter_degree_max}{Maximum degree of relatedness (default: 7)}
-    \item{title}{Plot title}
-    \item{subtitle}{Plot subtitle}
+    \item{plot_title}{Plot title}
+    \item{plot_subtitle}{Plot subtitle}
     \item{color_scale}{Paletteer color scale name (e.g., "ggthemes::calc")}
-    \item{only_classic_kin}{If TRUE, only classic kin are shown}
-    \item{kin_grouping}{If TRUE, use classic kin × mtDNA for grouping}
+    \item{use_only_classic_kin}{If TRUE, only classic kin are shown}
+    \item{group_by_kin}{If TRUE, use classic kin × mtDNA for grouping}
     \item{drop_classic_kin}{If TRUE, remove classic kin rows}
     \item{drop_non_classic_sibs}{If TRUE, remove non-classic sibs (default: TRUE)}
-    \item{annotate}{If TRUE, annotate mother/father/sibling points}
-    \item{annotate_xshift}{Relative x-axis shift for annotations}
-    \item{annotate_yshift}{Relative y-axis shift for annotations}
+    \item{annotate_include}{If TRUE, annotate mother/father/sibling points}
+    \item{annotate_x_shift}{Relative x-axis shift for annotations}
+    \item{annotate_y_shift}{Relative y-axis shift for annotations}
     \item{point_size}{Size of geom_point points (default: 1)}
-    \item{degree_rel}{If TRUE, x-axis uses degree-of-relatedness scaling}
-    \item{grouping}{Grouping column name (default: mtdna_factor)}
-    \item{rounding}{Number of decimal places for rounding (default: 2)}
-    \item{threshold}{Tolerance \% for matching known degrees}
-    \item{max_degrees}{Maximum number of degrees to consider}
+    \item{use_relative_degree}{If TRUE, x-axis uses degree-of-relatedness scaling}
+    \item{grouping_column}{Grouping column name (default: mtdna_factor)}
+    \item{value_rounding_digits}{Number of decimal places for rounding (default: 2)}
+    \item{match_threshold_percent}{Tolerance \% for matching known degrees}
+    \item{max_degree_levels}{Maximum number of degrees to consider}
 }}
 }
 \value{

--- a/man/getDefaultPlotConfig.Rd
+++ b/man/getDefaultPlotConfig.Rd
@@ -282,6 +282,8 @@ getDefaultPlotConfig(
 
 \item{sex_shape_labels}{Labels used in sex legend.}
 
+\item{sex_color_palette}{A character vector of colors for sex.}
+
 \item{sex_shape_female}{Shape for female nodes.}
 
 \item{sex_shape_male}{Shape for male nodes.}
@@ -301,6 +303,8 @@ getDefaultPlotConfig(
 \item{status_alpha_affected}{Alpha for affected individuals.}
 
 \item{status_alpha_unaffected}{Alpha for unaffected individuals.}
+
+\item{status_color_palette}{A character vector of colors for affected status.}
 
 \item{status_affected_shape}{Shape for affected individuals.}
 

--- a/man/getDefaultPlotConfig.Rd
+++ b/man/getDefaultPlotConfig.Rd
@@ -5,28 +5,350 @@
 \title{Shared Default Plotting Configuration}
 \usage{
 getDefaultPlotConfig(
-  color_palette_default = c("#440154FF", "#FDE725FF", "#21908CFF"),
-  segment_default_color = "black",
   function_name = "getDefaultPlotConfig",
   personID = "personID",
-  color_scale_midpoint = 0.5,
-  alpha_default = 1,
   status_column = NULL,
+  alpha_default = 1,
+  apply_default_scales = TRUE,
+  apply_default_theme = TRUE,
+  segment_default_color = "black",
+  color_palette_default = c("#440154FF", "#FDE725FF", "#21908CFF"),
+  color_palette_low = "#000004FF",
+  color_palette_mid = "#56106EFF",
+  color_palette_high = "#FCFDBFFF",
+  color_scale_midpoint = 0.5,
+  color_scale = "ggthemes::calc",
+  alpha = alpha_default,
+  plot_title = NULL,
+  plot_subtitle = NULL,
+  value_rounding_digits = 2,
+  code_male = 1,
+  filter_n_pairs = 500,
+  filter_degree_min = 0,
+  filter_degree_max = 7,
+  drop_classic_kin = FALSE,
+  drop_non_classic_sibs = TRUE,
+  use_only_classic_kin = TRUE,
+  use_relative_degree = TRUE,
+  group_by_kin = TRUE,
+  match_threshold_percent = 10,
+  max_degree_levels = 12,
+  grouping_column = "mtdna_factor",
+  annotate_include = TRUE,
+  annotate_x_shift = -0.1,
+  annotate_y_shift = 0.005,
+  label_include = TRUE,
+  label_column = "personID",
+  label_method = "ggrepel",
+  label_max_overlaps = 15,
+  label_nudge_x = 0,
+  label_nudge_y = -0.1,
+  label_segment_color = NA,
+  label_text_angle = 0,
+  label_text_size = 2,
+  label_text_color = "black",
+  point_size = 4,
+  outline_include = FALSE,
+  outline_multiplier = 1.25,
+  outline_color = "black",
+  tooltip_include = TRUE,
+  tooltip_columns = c("ID1", "ID2", "value"),
+  axis_x_label = NULL,
+  axis_y_label = NULL,
+  axis_text_angle_x = 90,
+  axis_text_angle_y = 0,
+  axis_text_size = 8,
+  axis_text_color = "black",
+  generation_height = 1,
+  generation_width = 1,
+  ped_packed = TRUE,
+  ped_align = TRUE,
+  ped_width = 15,
+  segment_linewidth = 0.5,
+  segment_linetype = 1,
+  segment_lineend = "round",
+  segment_linejoin = "round",
+  segment_offspring_color = segment_default_color,
+  segment_parent_color = segment_default_color,
+  segment_self_color = segment_default_color,
+  segment_sibling_color = segment_default_color,
+  segment_spouse_color = segment_default_color,
+  segment_mz_color = segment_default_color,
+  segment_mz_linetype = 1,
+  segment_mz_alpha = 1,
+  segment_mz_t = 0.6,
+  segment_self_linetype = "dotdash",
+  segment_self_alpha = 0.5,
+  segment_self_angle = 90,
+  segment_self_curvature = -0.2,
+  sex_color_include = TRUE,
+  sex_legend_title = "Sex",
+  sex_shape_labels = c("Female", "Male", "Unknown"),
+  sex_color_palette = color_palette_default,
+  sex_shape_female = 16,
+  sex_shape_male = 15,
+  sex_shape_unknown = 18,
+  status_include = TRUE,
+  status_code_affected = 1,
+  status_code_unaffected = 0,
+  status_label_affected = "Affected",
+  status_label_unaffected = "Unaffected",
+  status_alpha_affected = 1,
+  status_alpha_unaffected = 0,
+  status_color_palette = c(color_palette_default[1], color_palette_default[2]),
+  status_affected_shape = 4,
+  status_legend_title = "Affected",
+  status_legend_show = FALSE,
+  focal_fill_include = FALSE,
+  focal_fill_legend_show = TRUE,
+  focal_fill_personID = 1,
+  focal_fill_legend_title = "Focal Fill",
+  focal_fill_high_color = "#FDE725FF",
+  focal_fill_mid_color = "#9F2A63FF",
+  focal_fill_low_color = "#0D082AFF",
+  focal_fill_scale_midpoint = color_scale_midpoint,
+  focal_fill_method = "gradient",
+  focal_fill_component = "additive",
+  focal_fill_n_breaks = NULL,
+  focal_fill_na_value = "black",
+  focal_fill_force_zero = FALSE,
+  ci_include = TRUE,
+  ci_ribbon_alpha = 0.3,
+  matrix_sparse = FALSE,
+  matrix_isChild_method = "partialparent",
+  return_static = TRUE,
+  return_widget = FALSE,
+  return_interactive = FALSE,
+  override_many2many = FALSE,
   ...
 )
 }
 \arguments{
-\item{color_palette_default}{A character vector of default colors for the plot.}
-
-\item{segment_default_color}{A character string for the default color of segments in the plot.}
-
 \item{function_name}{The name of the function calling this configuration.}
 
 \item{personID}{The column name for person identifiers in the data.}
 
-\item{color_scale_midpoint}{A numeric value for the midpoint of the color scale.}
-
 \item{status_column}{The column name for affected status in the data.}
+
+\item{alpha_default}{Default alpha transparency level.}
+
+\item{apply_default_scales}{Whether to apply default color scales.}
+
+\item{apply_default_theme}{Whether to apply default ggplot2 theme.}
+
+\item{segment_default_color}{A character string for the default color of segments in the plot.}
+
+\item{color_palette_default}{A character vector of default colors for the plot.}
+
+\item{color_palette_low}{Color for the low end of a gradient.}
+
+\item{color_palette_mid}{Color for the midpoint of a gradient.}
+
+\item{color_palette_high}{Color for the high end of a gradient.}
+
+\item{color_scale_midpoint}{Midpoint value for continuous color scales.}
+
+\item{color_scale}{Name of the color scale used (e.g., "ggthemes::calc").}
+
+\item{alpha}{Default alpha transparency for plot elements.}
+
+\item{plot_title}{Main title of the plot.}
+
+\item{plot_subtitle}{Subtitle of the plot.}
+
+\item{value_rounding_digits}{Number of digits to round displayed values.}
+
+\item{code_male}{Integer code for males in data.}
+
+\item{filter_n_pairs}{Threshold to filter maximum number of pairs.}
+
+\item{filter_degree_min}{Minimum degree value used in filtering.}
+
+\item{filter_degree_max}{Maximum degree value used in filtering.}
+
+\item{drop_classic_kin}{Whether to exclude classic kin categories.}
+
+\item{drop_non_classic_sibs}{Whether to exclude non-classic sibs.}
+
+\item{use_only_classic_kin}{Whether to restrict analysis to classic kinship.}
+
+\item{use_relative_degree}{Whether to use relative degrees instead of absolute.}
+
+\item{group_by_kin}{Whether to group output by kinship group.}
+
+\item{match_threshold_percent}{Kinbin matching threshold as a percentage.}
+
+\item{max_degree_levels}{Maximum number of degree levels to show.}
+
+\item{grouping_column}{Name of column used for grouping.}
+
+\item{annotate_include}{Whether to include annotations.}
+
+\item{annotate_x_shift}{Horizontal shift applied to annotation text.}
+
+\item{annotate_y_shift}{Vertical shift applied to annotation text.}
+
+\item{label_include}{Whether to display labels on plot points.}
+
+\item{label_column}{Column to use for text labels.}
+
+\item{label_method}{Method used for labeling (e.g., ggrepel, geom_text).}
+
+\item{label_max_overlaps}{Maximum number of overlapping labels.}
+
+\item{label_nudge_x}{Horizontal nudge for label text.}
+
+\item{label_nudge_y}{Vertical nudge for label text.}
+
+\item{label_segment_color}{Segment color for label connectors.}
+
+\item{label_text_angle}{Text angle for labels.}
+
+\item{label_text_size}{Font size for labels.}
+
+\item{label_text_color}{Color of the label text.}
+
+\item{point_size}{Size of points drawn in plot.}
+
+\item{outline_include}{Whether to include outlines around points.}
+
+\item{outline_multiplier}{Multiplier to compute outline size from point size.}
+
+\item{outline_color}{Color used for point outlines.}
+
+\item{tooltip_include}{Whether tooltips are shown in interactive plots.}
+
+\item{tooltip_columns}{Columns to include in tooltips.}
+
+\item{axis_x_label}{Label for the X-axis.}
+
+\item{axis_y_label}{Label for the Y-axis.}
+
+\item{axis_text_angle_x}{Angle of X-axis text.}
+
+\item{axis_text_angle_y}{Angle of Y-axis text.}
+
+\item{axis_text_size}{Font size of axis text.}
+
+\item{axis_text_color}{Color of axis text.}
+
+\item{generation_height}{Vertical spacing of generations.}
+
+\item{generation_width}{Horizontal spacing of generations.}
+
+\item{ped_packed}{Whether the pedigree should use packed layout.}
+
+\item{ped_align}{Whether to align pedigree generations.}
+
+\item{ped_width}{Plot width of the pedigree block.}
+
+\item{segment_linewidth}{Line width for segments.}
+
+\item{segment_linetype}{Line type for segments.}
+
+\item{segment_lineend}{Line end type for segments.}
+
+\item{segment_linejoin}{Line join type for segments.}
+
+\item{segment_offspring_color}{Color for offspring segments.}
+
+\item{segment_parent_color}{Color for parent segments.}
+
+\item{segment_self_color}{Color for self-loop segments.}
+
+\item{segment_sibling_color}{Color for sibling segments.}
+
+\item{segment_spouse_color}{Color for spouse segments.}
+
+\item{segment_mz_color}{Color for monozygotic twin segments.}
+
+\item{segment_mz_linetype}{Line type for MZ segments.}
+
+\item{segment_mz_alpha}{Alpha for MZ segments.}
+
+\item{segment_mz_t}{Tuning parameter for MZ segment layout.}
+
+\item{segment_self_linetype}{Line type for self-loop segments.}
+
+\item{segment_self_alpha}{Alpha value for self-loop segments.}
+
+\item{segment_self_angle}{Angle of self-loop segment.}
+
+\item{segment_self_curvature}{Curvature of self-loop segment.}
+
+\item{sex_color_include}{Whether to color nodes by sex.}
+
+\item{sex_legend_title}{Title of the sex legend.}
+
+\item{sex_shape_labels}{Labels used in sex legend.}
+
+\item{sex_shape_female}{Shape for female nodes.}
+
+\item{sex_shape_male}{Shape for male nodes.}
+
+\item{sex_shape_unknown}{Shape for unknown sex nodes.}
+
+\item{status_include}{Whether to display affected status.}
+
+\item{status_code_affected}{Value that encodes affected status.}
+
+\item{status_code_unaffected}{Value that encodes unaffected status.}
+
+\item{status_label_affected}{Label for affected status.}
+
+\item{status_label_unaffected}{Label for unaffected status.}
+
+\item{status_alpha_affected}{Alpha for affected individuals.}
+
+\item{status_alpha_unaffected}{Alpha for unaffected individuals.}
+
+\item{status_affected_shape}{Shape for affected individuals.}
+
+\item{status_legend_title}{Title of the status legend.}
+
+\item{status_legend_show}{Whether to show the status legend.}
+
+\item{focal_fill_include}{Whether to fill focal individuals.}
+
+\item{focal_fill_legend_show}{Whether to show legend for focal fill.}
+
+\item{focal_fill_personID}{ID of focal individual.}
+
+\item{focal_fill_legend_title}{Title of focal fill legend.}
+
+\item{focal_fill_high_color}{High-end color for focal gradient.}
+
+\item{focal_fill_mid_color}{Midpoint color for focal gradient.}
+
+\item{focal_fill_low_color}{Low-end color for focal gradient.}
+
+\item{focal_fill_scale_midpoint}{Midpoint for focal fill scale.}
+
+\item{focal_fill_method}{Method used for focal fill gradient.}
+
+\item{focal_fill_component}{Component type for focal fill.}
+
+\item{focal_fill_n_breaks}{Number of breaks in focal fill scale.}
+
+\item{focal_fill_na_value}{Color for NA values in focal fill.}
+
+\item{focal_fill_force_zero}{Whether to force zero to NA in focal fill.}
+
+\item{ci_include}{Whether to show confidence intervals.}
+
+\item{ci_ribbon_alpha}{Alpha level for CI ribbons.}
+
+\item{matrix_sparse}{Whether matrix input is sparse.}
+
+\item{matrix_isChild_method}{Method used for isChild matrix derivation.}
+
+\item{return_static}{Whether to return a static plot.}
+
+\item{return_widget}{Whether to return a widget object.}
+
+\item{return_interactive}{Whether to return an interactive plot.}
+
+\item{override_many2many}{Whether to override many-to-many link logic.}
 
 \item{...}{Additional arguments for future extensibility.}
 }
@@ -35,4 +357,8 @@ A named list of default plotting and layout parameters.
 }
 \description{
 Centralized configuration list used by all gg-based plotting functions.
+Returns a named list of default settings used by all gg-based plotting functions.
+This configuration can be overridden by supplying a list of key-value pairs to
+plotting functions such as `ggPedigree()`, `ggRelatednessMatrix()`, and `ggPhenotypeByDegree()`.
+Each key corresponds to a configurable plot, layout, or aesthetic behavior.
 }

--- a/man/getDefaultPlotConfig.Rd
+++ b/man/getDefaultPlotConfig.Rd
@@ -10,6 +10,7 @@ getDefaultPlotConfig(
   function_name = "getDefaultPlotConfig",
   personID = "personID",
   color_scale_midpoint = 0.5,
+  alpha_default = 1,
   status_column = NULL,
   ...
 )

--- a/man/ggPhenotypeByDegree.Rd
+++ b/man/ggPhenotypeByDegree.Rd
@@ -41,22 +41,22 @@ ggPhenotypeByDegree(
     \item{filter_n_pairs}{Minimum number of pairs to include (default: 500)}
     \item{filter_degree_min}{Minimum degree of relatedness (default: 0)}
     \item{filter_degree_max}{Maximum degree of relatedness (default: 7)}
-    \item{title}{Plot title}
-    \item{subtitle}{Plot subtitle}
+    \item{plot_title}{Plot title}
+    \item{plot_subtitle}{Plot subtitle}
     \item{color_scale}{Paletteer color scale name (e.g., "ggthemes::calc")}
-    \item{only_classic_kin}{If TRUE, only classic kin are shown}
-    \item{kin_grouping}{If TRUE, use classic kin × mtDNA for grouping}
+    \item{use_only_classic_kin}{If TRUE, only classic kin are shown}
+    \item{group_by_kin}{If TRUE, use classic kin × mtDNA for grouping}
     \item{drop_classic_kin}{If TRUE, remove classic kin rows}
     \item{drop_non_classic_sibs}{If TRUE, remove non-classic sibs (default: TRUE)}
-    \item{annotate}{If TRUE, annotate mother/father/sibling points}
-    \item{annotate_xshift}{Relative x-axis shift for annotations}
-    \item{annotate_yshift}{Relative y-axis shift for annotations}
+    \item{annotate_include}{If TRUE, annotate mother/father/sibling points}
+    \item{annotate_x_shift}{Relative x-axis shift for annotations}
+    \item{annotate_y_shift}{Relative y-axis shift for annotations}
     \item{point_size}{Size of geom_point points (default: 1)}
-    \item{degree_rel}{If TRUE, x-axis uses degree-of-relatedness scaling}
-    \item{grouping}{Grouping column name (default: mtdna_factor)}
-    \item{rounding}{Number of decimal places for rounding (default: 2)}
-    \item{threshold}{Tolerance \% for matching known degrees}
-    \item{max_degrees}{Maximum number of degrees to consider}
+    \item{use_relative_degree}{If TRUE, x-axis uses degree-of-relatedness scaling}
+    \item{grouping_column}{Grouping column name (default: mtdna_factor)}
+    \item{value_rounding_digits}{Number of decimal places for rounding (default: 2)}
+    \item{match_threshold_percent}{Tolerance \% for matching known degrees}
+    \item{max_degree_levels}{Maximum number of degrees to consider}
 }}
 
 \item{data_prep}{Logical; if TRUE, performs data preparation steps.}

--- a/man/ggPhenotypeByDegree.core.Rd
+++ b/man/ggPhenotypeByDegree.core.Rd
@@ -41,22 +41,22 @@ ggPhenotypeByDegree.core(
     \item{filter_n_pairs}{Minimum number of pairs to include (default: 500)}
     \item{filter_degree_min}{Minimum degree of relatedness (default: 0)}
     \item{filter_degree_max}{Maximum degree of relatedness (default: 7)}
-    \item{title}{Plot title}
-    \item{subtitle}{Plot subtitle}
+    \item{plot_title}{Plot title}
+    \item{plot_subtitle}{Plot subtitle}
     \item{color_scale}{Paletteer color scale name (e.g., "ggthemes::calc")}
-    \item{only_classic_kin}{If TRUE, only classic kin are shown}
-    \item{kin_grouping}{If TRUE, use classic kin × mtDNA for grouping}
+    \item{use_only_classic_kin}{If TRUE, only classic kin are shown}
+    \item{group_by_kin}{If TRUE, use classic kin × mtDNA for grouping}
     \item{drop_classic_kin}{If TRUE, remove classic kin rows}
     \item{drop_non_classic_sibs}{If TRUE, remove non-classic sibs (default: TRUE)}
-    \item{annotate}{If TRUE, annotate mother/father/sibling points}
-    \item{annotate_xshift}{Relative x-axis shift for annotations}
-    \item{annotate_yshift}{Relative y-axis shift for annotations}
+    \item{annotate_include}{If TRUE, annotate mother/father/sibling points}
+    \item{annotate_x_shift}{Relative x-axis shift for annotations}
+    \item{annotate_y_shift}{Relative y-axis shift for annotations}
     \item{point_size}{Size of geom_point points (default: 1)}
-    \item{degree_rel}{If TRUE, x-axis uses degree-of-relatedness scaling}
-    \item{grouping}{Grouping column name (default: mtdna_factor)}
-    \item{rounding}{Number of decimal places for rounding (default: 2)}
-    \item{threshold}{Tolerance \% for matching known degrees}
-    \item{max_degrees}{Maximum number of degrees to consider}
+    \item{use_relative_degree}{If TRUE, x-axis uses degree-of-relatedness scaling}
+    \item{grouping_column}{Grouping column name (default: mtdna_factor)}
+    \item{value_rounding_digits}{Number of decimal places for rounding (default: 2)}
+    \item{match_threshold_percent}{Tolerance \% for matching known degrees}
+    \item{max_degree_levels}{Maximum number of degrees to consider}
 }}
 
 \item{...}{Additional arguments passed to `ggplot2` functions.}

--- a/tests/testthat/test-defaultPlotConfig.R
+++ b/tests/testthat/test-defaultPlotConfig.R
@@ -18,7 +18,7 @@ test_that("getDefaultPlotConfig returns expected defaults", {
   config <- getDefaultPlotConfig()
 
   expect_true(is.list(config))
-  expect_equal(length(config), 105) # Check number of default parameters
+  expect_equal(length(config), 110) # Check number of default parameters
 
   expect_equal(config$apply_default_scales, TRUE)
   expect_equal(config$apply_default_theme, TRUE)

--- a/tests/testthat/test-ggPhenotypeByDegree.R
+++ b/tests/testthat/test-ggPhenotypeByDegree.R
@@ -144,7 +144,7 @@ test_that("ggPhenotypeByDegree handles different thresholds", {
     y_se = "y_se",
     config = list(
       apply_default_theme = FALSE,
-      match_threshold_percent  = 20
+      match_threshold_percent = 20
     )
   )
 

--- a/tests/testthat/test-ggPhenotypeByDegree.R
+++ b/tests/testthat/test-ggPhenotypeByDegree.R
@@ -76,8 +76,8 @@ test_that("ggPhenotypeByDegree applies custom  drops correctly", {
     config = list(
       drop_classic_kin = TRUE,
       default_scales = FALSE,
-      degree_rel = FALSE,
-      annotate = FALSE
+      use_relative_degree = FALSE,
+      annotate_include = FALSE
     )
   )
 
@@ -109,8 +109,8 @@ test_that("ggPhenotypeByDegree applies custom configurations", {
     y_se = "y_se",
     config = list(
       apply_default_theme = FALSE,
-      title = "Custom Title",
-      subtitle = "Custom Subtitle"
+      plot_title = "Custom Title",
+      plot_subtitle = "Custom Subtitle"
     )
   )
 
@@ -144,7 +144,7 @@ test_that("ggPhenotypeByDegree handles different thresholds", {
     y_se = "y_se",
     config = list(
       apply_default_theme = FALSE,
-      threshold = 20
+      match_threshold_percent  = 20
     )
   )
 

--- a/vignettes/articles/v3_phenotypicbydegree.Rmd
+++ b/vignettes/articles/v3_phenotypicbydegree.Rmd
@@ -184,7 +184,8 @@ ggPhenotypeByDegree(
   config = list(
     only_classic_kin = FALSE,
     degree_rel = FALSE,
-    kin_grouping = TRUE
+    kin_grouping = TRUE,
+    
   )
 )
 ```

--- a/vignettes/articles/v3_phenotypicbydegree.Rmd
+++ b/vignettes/articles/v3_phenotypicbydegree.Rmd
@@ -32,8 +32,7 @@ library(dplyr)
 library(purrr) # for map_* helpers
 # Filter for the largest family, recode sex if needed
 ped_filtered <- redsquirrels %>%
-  recodeSex(code_female = "F") #%>%
-  filter(famID == 160)
+  recodeSex(code_female = "F")  %>% filter(famID == 160)
 
 kin_degree_max <- 12 # maximum degree of relatedness to consider
 # Calculate relatedness matrices
@@ -93,8 +92,12 @@ assign_addRel_bin <- function(rel) {
       return(paste0("addRel_+", val))
     }
   }
-  if (!is.na(rel) && rel > 2^0 * 1.1) return("addRel_1+")
-  if (!is.na(rel) && rel == 0) return("addRel_0")
+  if (!is.na(rel) && rel > 2^0 * 1.1) {
+    return("addRel_1+")
+  }
+  if (!is.na(rel) && rel == 0) {
+    return("addRel_0")
+  }
   return(NA_character_)
 }
 
@@ -139,16 +142,16 @@ result <- dataRelatedPair_merge %>%
     cor_lrs_stat = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$statistic),
     cor_lrs_p = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$p.value),
     cor_lrs_df = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$parameter),
-    cor_lrs_ci_lb = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1]*sqrt(2)),
-    cor_lrs_ci_ub = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2]*sqrt(2)),
+    cor_lrs_ci_lb = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1] * sqrt(2)),
+    cor_lrs_ci_ub = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2] * sqrt(2)),
 
     # ---- ARS‑n pair ----
     cor_ars_n = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$estimate),
     cor_ars_n_stat = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$statistic),
     cor_ars_n_p = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$p.value),
     cor_ars_n_df = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$parameter),
-    cor_ars_n_ci_lb = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1]*sqrt(2)),
-    cor_ars_n_ci_ub = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2]*sqrt(2))
+    cor_ars_n_ci_lb = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1] * sqrt(2)),
+    cor_ars_n_ci_ub = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2] * sqrt(2))
   ) %>%
   select(-lrs_cor_test, -ars_n_cor_test) %>% # drop the list‑columns once unpacked
   rename(cnu = cnuRel, mtdna = mitRel)

--- a/vignettes/articles/v3_phenotypicbydegree.Rmd
+++ b/vignettes/articles/v3_phenotypicbydegree.Rmd
@@ -32,7 +32,7 @@ library(dplyr)
 library(purrr) # for map_* helpers
 # Filter for the largest family, recode sex if needed
 ped_filtered <- redsquirrels %>%
-  recodeSex(code_female = "F") %>%
+  recodeSex(code_female = "F") #%>%
   filter(famID == 160)
 
 kin_degree_max <- 12 # maximum degree of relatedness to consider
@@ -49,7 +49,9 @@ df_links <- com2links(
   drop_upper_triangular = TRUE,
   gc = FALSE
 )
+```
 
+```{r message=FALSE, warning=FALSE} 
 dataRelatedPair_merge <- df_links %>%
   left_join(ped_filtered %>% select(personID, lrs, ars_n),
     by = c("ID1" = "personID")
@@ -75,6 +77,29 @@ dxlist <- c(
   names(dataRelatedPair_merge)[endsWith(names(dataRelatedPair_merge), "_k1")]
 )
 
+kin_degrees <- 0:12
+rel_vals <- 2^(-kin_degrees)
+rel_bins <- purrr::map_chr(rel_vals, ~ paste0("addRel_", .x))
+rel_labels <- c("addRel_1+" = "addRel_1+")
+
+# bin assignment function
+assign_addRel_bin <- function(rel) {
+  for (val in rel_vals) {
+    upper <- val * 1.1
+    lower <- val * 0.9
+    if (!is.na(rel) && rel >= lower && rel <= upper) {
+      return(paste0("addRel_", val))
+    } else if (!is.na(rel) && rel > upper) {
+      return(paste0("addRel_+", val))
+    }
+  }
+  if (!is.na(rel) && rel > 2^0 * 1.1) return("addRel_1+")
+  if (!is.na(rel) && rel == 0) return("addRel_0")
+  return(NA_character_)
+}
+
+
+
 dataRelatedPair_merge <- data.table::rbindlist(
   list(
     dataRelatedPair_merge,
@@ -82,59 +107,13 @@ dataRelatedPair_merge <- data.table::rbindlist(
   ),
   use.names = FALSE
 ) %>%
-  mutate(
-    # recode to bins that are within 10% of expected degree of relatedness cousins within 10% for .125 so .125+-.125*10 = .1125 and .125 + .125*10 = .1375, and 2^4 etc
-    #  addRel_center <- 2^(0:(-kin_degree_max)) # needs to be sliced first with range
-    addRel_bin = case_when(
-      addRel > 2^0 * 1.1 ~ "addRel_1+",
-      addRel > 2^0 * 0.9 & addRel < 2^0 * 1.1 ~ "addRel_1",
-      addRel > 2^(-1) * 1.1 ~ paste0("addRel_+", 2^(-1)),
-      addRel > 2^(-1) * 0.9 & addRel < 2^(-1) * 1.1 ~ paste0("addRel_", 2^(-1)),
-      addRel > 2^(-2) * 1.1 ~ paste0("addRel_+", 2^(-2)),
-      addRel > 2^(-2) * 0.9 & addRel < 2^(-2) * 1.1 ~ paste0("addRel_", 2^(-2)),
-      addRel > 2^(-3) * 1.1 ~ paste0("addRel_+", 2^(-3)),
-      addRel > 2^(-3) * 0.9 & addRel < 2^(-3) * 1.1 ~ paste0("addRel_", 2^(-3)),
-      addRel > 2^(-4) * 1.1 ~ paste0("addRel_+", 2^(-4)),
-      addRel > 2^(-4) * 0.9 & addRel < 2^(-4) * 1.1 ~ paste0("addRel_", 2^(-4)),
-      addRel > 2^(-5) * 1.1 ~ paste0("addRel_+", 2^(-5)),
-      addRel > 2^(-5) * 0.9 & addRel < 2^(-5) * 1.1 ~ paste0("addRel_", 2^(-5)),
-      addRel > 2^(-6) * 1.1 ~ paste0("addRel_+", 2^(-6)),
-      addRel > 2^(-6) * 0.9 & addRel < 2^(-6) * 1.1 ~ paste0("addRel_", 2^(-6)),
-      addRel > 2^(-7) * 1.1 ~ paste0("addRel_+", 2^(-7)),
-      addRel > 2^(-7) * 0.9 & addRel < 2^(-7) * 1.1 ~ paste0("addRel_", 2^(-7)),
-      addRel > 2^(-8) * 1.1 ~ paste0("addRel_+", 2^(-8)),
-      addRel > 2^(-8) * 0.9 & addRel < 2^(-8) * 1.1 ~ paste0("addRel_", 2^(-8)),
-      addRel > 2^(-9) * 1.1 ~ paste0("addRel_+", 2^(-9)),
-      addRel > 2^(-9) * 0.9 & addRel < 2^(-9) * 1.1 ~ paste0("addRel_", 2^(-9)),
-      addRel > 2^(-10) * 1.1 ~ paste0("addRel_+", 2^(-10)),
-      addRel > 2^(-10) * 0.9 & addRel < 2^(-10) * 1.1 ~ paste0("addRel_", 2^(-10)),
-      addRel > 2^(-11) * 1.1 ~ paste0("addRel_+", 2^(-11)),
-      addRel > 2^(-11) * 0.9 & addRel < 2^(-11) * 1.1 ~ paste0("addRel_", 2^(-11)),
-      addRel > 2^(-12) * 1.1 ~ paste0("addRel_+", 2^(-12)),
-      addRel > 2^(-12) * 0.9 & addRel < 2^(-12) * 1.1 ~ paste0("addRel_", 2^(-12)),
-      addRel > 0 ~ "addRel_+0",
-      addRel == 0 ~ "addRel_0",
-      TRUE ~ NA_character_ # catch-all for other cases
-    ),
-    addRel_factor = factor(addRel_bin, levels = c(
-      "addRel_1+", "addRel_1", paste0("addRel_+", 2^(-1)),
-      paste0("addRel_", 2^(-1)), paste0("addRel_+", 2^(-2)),
-      paste0("addRel_", 2^(-2)), paste0("addRel_+", 2^(-3)),
-      paste0("addRel_", 2^(-3)), paste0("addRel_+", 2^(-4)),
-      paste0("addRel_", 2^(-4)), paste0("addRel_+", 2^(-5)),
-      paste0("addRel_", 2^(-5)), paste0("addRel_+", 2^(-6)),
-      paste0("addRel_", 2^(-6)), paste0("addRel_+", 2^(-7)),
-      paste0("addRel_", 2^(-7)), paste0("addRel_+", 2^(-8)),
-      paste0("addRel_", 2^(-8)), paste0("addRel_+", 2^(-9)),
-      paste0("addRel_", 2^(-9)), paste0("addRel_+", 2^(-10)),
-      paste0("addRel_", 2^(-10)), paste0("addRel_+", 2^(-11)),
-      paste0("addRel_", 2^(-11)), paste0("addRel_+", 2^(-12)),
-      paste0("addRel_", 2^(-12)), "addRel_+0", "addRel_0"
-    ))
-  ) %>%
-  select(
-    -addRel_bin
-  )
+  mutate(addRel_bin = vapply(addRel, assign_addRel_bin, character(1))) %>%
+  mutate(addRel_factor = factor(addRel_bin, levels = c("addRel_1+", rel_bins, paste0("addRel_+", rel_vals), "addRel_+0", "addRel_0"))) %>%
+  select(-addRel_bin)
+
+
+
+
 
 
 result <- dataRelatedPair_merge %>%
@@ -160,21 +139,22 @@ result <- dataRelatedPair_merge %>%
     cor_lrs_stat = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$statistic),
     cor_lrs_p = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$p.value),
     cor_lrs_df = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$parameter),
-    cor_lrs_ci_lb = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1]),
-    cor_lrs_ci_ub = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2]),
+    cor_lrs_ci_lb = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1]*sqrt(2)),
+    cor_lrs_ci_ub = map_dbl(lrs_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2]*sqrt(2)),
 
     # ---- ARS‑n pair ----
     cor_ars_n = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$estimate),
     cor_ars_n_stat = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$statistic),
     cor_ars_n_p = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$p.value),
     cor_ars_n_df = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$parameter),
-    cor_ars_n_ci_lb = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1]),
-    cor_ars_n_ci_ub = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2])
+    cor_ars_n_ci_lb = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[1]*sqrt(2)),
+    cor_ars_n_ci_ub = map_dbl(ars_n_cor_test, ~ if (is.null(.x)) NA_real_ else .x$conf.int[2]*sqrt(2))
   ) %>%
   select(-lrs_cor_test, -ars_n_cor_test) %>% # drop the list‑columns once unpacked
   rename(cnu = cnuRel, mtdna = mitRel)
 ```
 </details>
+
 ```{r, message=FALSE, warning=FALSE}
 ggPhenotypeByDegree(
   df = result,
@@ -182,10 +162,14 @@ ggPhenotypeByDegree(
   y_ci_lb = "cor_lrs_ci_lb",
   y_ci_ub = "cor_lrs_ci_ub",
   config = list(
-    only_classic_kin = FALSE,
-    degree_rel = FALSE,
-    kin_grouping = TRUE,
-    
+    use_only_classic_kin = FALSE,
+    drop_classic_kin = FALSE,
+    group_by_kin = TRUE,
+    use_relative_degree = TRUE,
+    drop_non_classic_sibs = FALSE,
+    filter_degree_max = 12,
+    grouping_column = "mtdna_factor",
+    filter_n_pairs = 10
   )
 )
 ```


### PR DESCRIPTION
This pull request introduces enhancements to the `ggPhenotypeByDegree` functionality, refines configuration handling, and improves naming consistency across the codebase. The changes include adding support for confidence intervals, restructuring configuration defaults, and aligning parameter names for clarity and consistency.

### Enhancements to `ggPhenotypeByDegree` functionality:
* Added support for confidence intervals (`ci_include`, `ci_ribbon_alpha`) in `getDefaultPlotConfig` to enhance visualizations with shaded regions for uncertainty. ([[1]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R171-R182), [[2]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL225-R243), [[3]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL250-R260))
* Integrated `getDefaultPlotConfig` and `buildPlotConfig` to streamline configuration management for `ggPhenotypeByDegree`. (`Fbdbd1f8L14R14`, [[1]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fR72-R115), [[2]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R287-R292))

### Configuration and parameter improvements:
* Renamed parameters for clarity, such as `only_classic_kin` → `use_only_classic_kin`, `kin_grouping` → `group_by_kin`, and `degree_rel` → `use_relative_degree`. ([[1]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5L59-R64), [[2]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL160-R180), [[3]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL282-R302))
* Updated annotation-related parameters (`annotate` → `annotate_include`, `annotate_xshift` → `annotate_x_shift`) for better readability and alignment. ([[1]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL181-R196)`, [[2]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL264-R274)`)
* Enhanced naming consistency for threshold and degree parameters (`threshold` → `match_threshold_percent`, `max_degrees` → `max_degree_levels`). (`[[1]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL358-R369)`, `[[2]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL369-R381)`)

### Documentation updates:
* Updated documentation in `man/dot-addAnnotate.Rd` and `R/ggPhenotypeByDegree.R` to reflect new parameter names and defaults, ensuring clarity for users. (`[[1]](diffhunk://#diff-d49700e415e96ce4ce758822895c671c1476b7d39d8755712cd1bec149af41ffL15-R30)`, `[[2]](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL27-R42)`)

These changes collectively improve functionality, maintainability, and usability of the `ggPhenotypeByDegree` plotting features.