### PR TITLE
Minor features

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,9 +25,9 @@ Imports:
     plotly,
     reshape2,
     scales,
-    tidyr,
-    paletteer
+    tidyr
 Suggests: 
+    paletteer,
     mockery,
     patchwork,
     viridis,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 * Fixed focal_fill ID being indexed to row order, rather than the ID order.
 * Fixed bug in using fam_x and fam_y in with generation_height
 * Add option to add phantom parents to the pedigree plot.
-* Alerts  when duplicate or bad configs are used
+* Alerts when duplicate or bad configs are used
+* Make palleter suggested instead of required
 
 # ggpedigree 0.7.0
 * Changed the default behavior of `ggPedigree` to use x_fam and y_fam for positioning families, rather than x_midparent and y_midparent. This change allows for better visualization of pedigrees with multiple families.

--- a/R/defaultPlotConfig.R
+++ b/R/defaultPlotConfig.R
@@ -48,6 +48,7 @@
 #' @param label_text_angle Text angle for labels.
 #' @param label_text_size Font size for labels.
 #' @param label_text_color Color of the label text.
+#' @param label_text_family Font family for label text.
 #' @param point_size Size of points drawn in plot.
 #' @param outline_include Whether to include outlines around points.
 #' @param outline_multiplier Multiplier to compute outline size from point size.
@@ -60,6 +61,7 @@
 #' @param axis_text_angle_y Angle of Y-axis text.
 #' @param axis_text_size Font size of axis text.
 #' @param axis_text_color Color of axis text.
+#' @param axis_text_family Font family for axis text.
 #' @param generation_height Vertical spacing of generations.
 #' @param generation_width Horizontal spacing of generations.
 #' @param ped_packed Whether the pedigree should use packed layout.
@@ -210,6 +212,7 @@ getDefaultPlotConfig <- function(function_name = "getDefaultPlotConfig",
                                  label_text_angle = 0,
                                  label_text_size = 2,
                                  label_text_color = "black",
+                                 label_text_family = "sans",
                                  # --- POINT / OUTLINE AESTHETICS ---------------------------------------
                                  point_size = 4,
                                  outline_include = FALSE,
@@ -225,6 +228,7 @@ getDefaultPlotConfig <- function(function_name = "getDefaultPlotConfig",
                                  axis_text_angle_y = 0,
                                  axis_text_size = 8,
                                  axis_text_color = "black",
+                                 axis_text_family = "sans",
                                  # ---- Generation Scale Settings ----
                                  generation_height = 1,
                                  generation_width = 1,
@@ -409,6 +413,7 @@ getDefaultPlotConfig <- function(function_name = "getDefaultPlotConfig",
     label_text_angle = label_text_angle,
     label_text_size = label_text_size,
     label_text_color = label_text_color,
+    label_text_family = label_text_family,
 
     # --- POINT / OUTLINE AESTHETICS ---------------------------------------
     point_size = point_size,
@@ -427,6 +432,7 @@ getDefaultPlotConfig <- function(function_name = "getDefaultPlotConfig",
     axis_text_angle_y = axis_text_angle_y,
     axis_text_size = axis_text_size,
     axis_text_color = axis_text_color,
+    axis_text_family = axis_text_family,
 
     # ---- Generation Scale Settings ----
     generation_height = generation_height,

--- a/R/ggPhenotypeByDegree.R
+++ b/R/ggPhenotypeByDegree.R
@@ -293,11 +293,17 @@ ggPhenotypeByDegree.core <- function(df,
         fill = config$grouping_name
       )
   }
-  if (config$apply_default_scale == TRUE && !is.null(config$color_scale_theme) && requireNamespace("paletteer", quietly = TRUE)
+  if (config$apply_default_scale == TRUE && !is.null(config$color_scale_theme)
   ) {
-    core_plot <- core_plot +
-      paletteer::scale_color_paletteer_d(config$color_scale_theme) +
-      paletteer::scale_fill_paletteer_d(config$color_scale_theme)
+    if(requireNamespace("paletteer", quietly = TRUE)) {
+      # Use paletteer for color scales
+      core_plot <- core_plot +
+        paletteer::scale_color_paletteer_d(config$color_scale_theme) +
+        paletteer::scale_fill_paletteer_d(config$color_scale_theme)
+    } else {
+      warning("The 'paletteer' package is required for custom color scales.")
+    }
+
   } else if (config$apply_default_scale == TRUE) {
     core_plot <- core_plot +
       ggplot2::scale_color_brewer(palette = "Set1") +

--- a/R/ggpedigree.R
+++ b/R/ggpedigree.R
@@ -1106,10 +1106,12 @@ ggpedigree <- ggPedigree
         nudge_y = config$label_nudge_y * config$generation_height,
         nudge_x = config$label_nudge_x * config$generation_width,
         size = config$label_text_size,
+        color = config$label_text_color,
         na.rm = TRUE,
         max.overlaps = config$label_max_overlaps,
         segment.size = config$segment_linewidth * .5,
         angle = config$label_text_angle,
+        family = config$label_text_family,
         segment.color = config$label_segment_color
       )
   } else if (config$label_method == "geom_label") {
@@ -1117,7 +1119,9 @@ ggpedigree <- ggPedigree
       ggplot2::geom_label(ggplot2::aes(label = !!rlang::sym(config$label_column)),
         nudge_y = config$label_nudge_y * config$generation_height,
         nudge_x = config$label_nudge_x * config$generation_width,
+        color = config$label_text_color,
         size = config$label_text_size,
+        family = config$label_text_family,
         angle = config$label_text_angle,
         na.rm = TRUE
       )
@@ -1126,6 +1130,8 @@ ggpedigree <- ggPedigree
       ggplot2::geom_text(ggplot2::aes(label = !!rlang::sym(config$label_column)),
         nudge_y = config$label_nudge_y * config$generation_height,
         nudge_x = config$label_nudge_x * config$generation_width,
+        color = config$label_text_color,
+        family = config$label_text_family,
         size = config$label_text_size,
         angle = config$label_text_angle,
         na.rm = TRUE
@@ -1168,7 +1174,7 @@ ggpedigree <- ggPedigree
 #' @param angle Scalar angle in degrees
 #' @param shift Scalar shift in degrees (default is 0)
 #' @return Numeric vector of midpoints (x or y)
-#'  @keywords internal
+#' @keywords internal
 computeCurvedMidpoint <- function(x0, y0, x1, y1,
                                   curvature, angle, shift = 0,
                                   t = 0.5) {

--- a/man/computeCurvedMidpoint.Rd
+++ b/man/computeCurvedMidpoint.Rd
@@ -25,8 +25,8 @@ computeCurvedMidpoint(x0, y0, x1, y1, curvature, angle, shift = 0, t = 0.5)
 }
 \value{
 Numeric vector of midpoints (x or y)
- @keywords internal
 }
 \description{
 Returns x and y midpoint using vectorized curved offset
 }
+\keyword{internal}

--- a/man/getDefaultPlotConfig.Rd
+++ b/man/getDefaultPlotConfig.Rd
@@ -47,6 +47,7 @@ getDefaultPlotConfig(
   label_text_angle = 0,
   label_text_size = 2,
   label_text_color = "black",
+  label_text_family = "sans",
   point_size = 4,
   outline_include = FALSE,
   outline_multiplier = 1.25,
@@ -59,6 +60,7 @@ getDefaultPlotConfig(
   axis_text_angle_y = 0,
   axis_text_size = 8,
   axis_text_color = "black",
+  axis_text_family = "sans",
   generation_height = 1,
   generation_width = 1,
   ped_packed = TRUE,
@@ -244,6 +246,8 @@ getDefaultPlotConfig(
 
 \item{label_text_color}{Color of the label text.}
 
+\item{label_text_family}{Font family for label text.}
+
 \item{point_size}{Size of points drawn in plot.}
 
 \item{outline_include}{Whether to include outlines around points.}
@@ -267,6 +271,8 @@ getDefaultPlotConfig(
 \item{axis_text_size}{Font size of axis text.}
 
 \item{axis_text_color}{Color of axis text.}
+
+\item{axis_text_family}{Font family for axis text.}
 
 \item{generation_height}{Vertical spacing of generations.}
 

--- a/tests/testthat/test-defaultPlotConfig.R
+++ b/tests/testthat/test-defaultPlotConfig.R
@@ -18,7 +18,7 @@ test_that("getDefaultPlotConfig returns expected defaults", {
   config <- getDefaultPlotConfig()
 
   expect_true(is.list(config))
-  expect_equal(length(config), 143) # Check number of default parameters
+  expect_equal(length(config), 145) # Check number of default parameters
 
   expect_equal(config$apply_default_scales, TRUE)
   expect_equal(config$apply_default_theme, TRUE)


### PR DESCRIPTION
This pull request introduces several updates to the `ggpedigree` package, focusing on improving text customization, refining dependency management, and enhancing documentation. The most notable changes include making the `paletteer` package optional, adding new configuration options for text styling, and updating related documentation and tests.

### Dependency Management:
* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL28-R30): Made `paletteer` a suggested dependency instead of a required one, allowing users to opt out of installing it.
* [`NEWS.md`](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR6): Updated changelog to reflect the change in `paletteer` dependency status.

### Text Customization Enhancements:
* [`R/defaultPlotConfig.R`](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R51): Added new configuration options `label_text_family` and `axis_text_family` to allow specifying font families for labels and axis text. Default values set to `"sans"`. [[1]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R51) [[2]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R64) [[3]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R215) [[4]](diffhunk://#diff-41ccd3fd3d1c43346494e11ebc663e3ac8facd3fb719112828951ce7a1f231f5R231)
* [`R/ggpedigree.R`](diffhunk://#diff-e7ab52e447a8bc4d366453b2539b87bda5f25f4a0f6367819a54f87eb52a7d82R1109-R1124): Integrated `label_text_family` and `label_text_color` into `geom_text`, `geom_label`, and other text-related configurations for pedigree plots. [[1]](diffhunk://#diff-e7ab52e447a8bc4d366453b2539b87bda5f25f4a0f6367819a54f87eb52a7d82R1109-R1124) [[2]](diffhunk://#diff-e7ab52e447a8bc4d366453b2539b87bda5f25f4a0f6367819a54f87eb52a7d82R1133-R1134)

### Improved Handling of Optional Dependencies:
* [`R/ggPhenotypeByDegree.R`](diffhunk://#diff-ba8e749cf9bd3cc7e5f31ec8a73dc5842dea22b1aaee37e6226de5173d00188fL296-R306): Added a fallback mechanism to display a warning if `paletteer` is unavailable, ensuring graceful degradation of color scale functionality.

### Documentation Updates:
* [`man/getDefaultPlotConfig.Rd`](diffhunk://#diff-5f27e01885f50d290e07208543c02de1f45701074d09b401c67d55a84aaf34fdR249-R250): Documented the new `label_text_family` and `axis_text_family` parameters in the function reference. [[1]](diffhunk://#diff-5f27e01885f50d290e07208543c02de1f45701074d09b401c67d55a84aaf34fdR249-R250) [[2]](diffhunk://#diff-5f27e01885f50d290e07208543c02de1f45701074d09b401c67d55a84aaf34fdR275-R276)
* [`man/computeCurvedMidpoint.Rd`](diffhunk://#diff-d3fb6b72592ad2a668fd4d160a27c2324322152b4029536e78f46f06188ca448L28-R32): Corrected the keyword declaration for internal usage.

### Test Adjustments:
* [`tests/testthat/test-defaultPlotConfig.R`](diffhunk://#diff-e22c8c97a04e0698c2676e295eb92b8026b576334db5fa5869dbb60ce505e7cbL21-R21): Updated tests for `getDefaultPlotConfig` to account for the new parameters, increasing the expected parameter count from 143 to 145.